### PR TITLE
[EPGRefresh] Fix scan of Alternatives

### DIFF
--- a/epgrefresh/src/EPGRefresh.py
+++ b/epgrefresh/src/EPGRefresh.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import Screens.Standby
 
 # eServiceReference
-from enigma import eServiceReference, eServiceCenter
+from enigma import eServiceReference, eServiceCenter, getBestPlayableServiceReference
 
 # ...
 from ServiceReference import ServiceReference
@@ -210,6 +210,8 @@ class EPGRefresh:
 	def addServices(self, fromList, toList, channelIds):
 		for scanservice in fromList:
 			service = eServiceReference(scanservice.sref)
+			if (service.flags & eServiceReference.isGroup):
+				service = getBestPlayableServiceReference(eServiceReference(scanservice.sref), eServiceReference())
 			if not service.valid() \
 				or (service.flags & (eServiceReference.isMarker|eServiceReference.isDirectory)):
 


### PR DESCRIPTION
EPGRefresh handles Alternatives properly about everywhere else but sorts them out right before the actual scan as they all share NAMESPACE, TSID and ONID.
Proper NAMESPACE, TSID and ONID are _inside_ the bouquet an Alternative actually is, not inside its own SREF.
