### PR TITLE
Fix: GREEN button text overlaid in EPG Search after Add Timer

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -147,7 +147,7 @@ class EPGSearch(EPGSelection):
 		self.sort_type = 0
 		self.eventviewDialog = None
 		self["key_red"] = Button(_("IMDb Search"))
-		self["key_green"] = Button(_("Add Timer"))
+		self["key_green"] = Button()
 		self.key_green_choice = self.ADD_TIMER
 		self.key_red_choice = self.EMPTY
 		self["list"] = EPGSearchList(type = self.type, selChangedCB = self.onSelectionChanged, timer = session.nav.RecordTimer)


### PR DESCRIPTION
After a timer is added in EPGSearch using GREEN Add Timer, The GREEN button
hinh has both texts Add Timer and Change Timer overwriting each other.

Detailed reproduction steps in the Beyonwiz bug tracker:
https://bitbucket.org/beyonwiz/easy-ui-4/issue/381/green-button-text-overlaid-in-epg-search

Fixed by removing the text initialisation of the key_green button.

I am only able to test on Beyonwiz T3.