### PR TITLE
[MountManager] Handle newline in /etc/hostname correctly

### DIFF
--- a/networkbrowser/src/MountManager.py
+++ b/networkbrowser/src/MountManager.py
@@ -134,14 +134,14 @@ class AutoMountManager(Screen):
 	def hostEdit(self):
 		if os_path.exists("/etc/hostname"):
 			fp = open('/etc/hostname', 'r')
-			self.hostname = fp.read()
+			self.hostname = fp.readline().rstrip('\n')
 			fp.close()
 			self.session.openWithCallback(self.hostnameCallback, VirtualKeyBoard, title = (_("Enter new hostname for your Receiver")), text = self.hostname)
 
 	def hostnameCallback(self, callback = None):
 		if callback is not None and len(callback):
 			fp = open('/etc/hostname', 'w+')
-			fp.write(callback)
+			fp.write(callback + '\n')
 			fp.flush()
 			fsync(fp.fileno())
 			fp.close()


### PR DESCRIPTION
In Change hostname, the current code reads the whole /etc/hostname
as the text for the VirtualKeyBoard and doesn't strip the newline(s).

That means that there's a "hidden" newline in the VirtualKeyBoard
text that has to be skipped back over before the text can be edited.

This commit reads only the first line of /etc/hostname
(as does the Busybox hostname -F /etc/hostname) and strips the
newline from it before passing it to VirtualKeyBoard.

The newline is added back when /etc/hostname is written.