### PR TITLE
Enable EPGSearch HELP screen

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -13,6 +13,7 @@ from Screens.ChannelSelection import SimpleChannelSelection
 from Screens.ChoiceBox import ChoiceBox
 from Screens.EpgSelection import EPGSelection
 from Screens.MessageBox import MessageBox
+from Screens.HelpMenu import HelpableScreen
 from Screens.Screen import Screen
 from Plugins.SystemPlugins.Toolkit.NTIVirtualKeyBoard import NTIVirtualKeyBoard
 
@@ -134,6 +135,7 @@ class EPGSearch(EPGSelection):
 	def __init__(self, session, *args):
 		Screen.__init__(self, session)
 		self.skinName = ["EPGSearch", "EPGSelection"]
+		HelpableScreen.__init__(self)
 
 		self.searchargs = args
 		self.currSearch = ""


### PR DESCRIPTION
The "stripped copy of EPGSelection.__init__" in EPGSearch didn't
include the initialisation of EPGSelection.HelpableScreen, so there
was no connection to the HELP screen.

Added a call to HelpableScreen.__init__() and so made the HELP
screen accessible.