### PR TITLE
fix possible bsod

### DIFF
--- a/imdb/src/plugin.py
+++ b/imdb/src/plugin.py
@@ -53,7 +53,10 @@ config.plugins.imdb.ignore_tags = ConfigText(visible_width = 50, fixed_size = Fa
 
 def quoteEventName(eventName, safe="/()" + ''.join(map(chr,range(192,255)))):
 	# BBC uses '\x86' markers in program names, remove them
-	text = eventName.decode('utf8').replace(u'\x86', u'').replace(u'\x87', u'').encode('utf8')
+	try:
+		text = eventName.decode('utf8').replace(u'\x86', u'').replace(u'\x87', u'').encode('utf8')
+	except:
+		text = eventName
 	# IMDb doesn't seem to like urlencoded characters at all, hence the big "safe" list
 	return quote_plus(text, safe=safe)
 


### PR DESCRIPTION
15:54:30.948 {   } Screens/InfoBarGenerics.py:204 actionA KEY: 358 0 KEY_INFO INFO
15:54:30.951 {   } Components/ActionMap.py:46 action action ->  WizardActions info
15:54:31.896 { D } Traceback (most recent call last):
15:54:31.896 { D }   File "/usr/lib/enigma2/python/Components/ActionMap.py", line 48, in action
15:54:31.897 { D }   File "/usr/lib/enigma2/python/Plugins/Extensions/MediaPortal/resources/simpleplayer.py", line 1464, in openMovieinfo
15:54:31.915 { D }     self.session.open(IMDB, title)
15:54:31.915 { D }   File "/usr/lib/enigma2/python/mytest.py", line 321, in open
15:54:31.917 { D }     dlg = self.current_dialog = self.instantiateDialog(screen, *arguments, **kwargs)
15:54:31.917 { D }   File "/usr/lib/enigma2/python/mytest.py", line 259, in instantiateDialog
15:54:31.918 { D }     return self.doInstantiateDialog(screen, arguments, kwargs, self.desktop)
15:54:31.918 { D }   File "/usr/lib/enigma2/python/mytest.py", line 281, in doInstantiateDialog
15:54:31.924 { D }     dlg = screen(self, *arguments, **kwargs)
15:54:31.925 { D }   File "/usr/lib/enigma2/python/Plugins/Extensions/IMDb/plugin.py", line 208, in __init__
15:54:31.925 { D }   File "/usr/lib/enigma2/python/Plugins/Extensions/IMDb/plugin.py", line 599, in getIMDB
15:54:31.926 { D }   File "/usr/lib/enigma2/python/Plugins/Extensions/IMDb/plugin.py", line 56, in quoteEventName
15:54:31.927 { D }   File "/usr/lib/python2.7/encodings/utf_8.py", line 16, in decode
15:54:31.928 { D } UnicodeDecodeError: 'utf8' codec can't decode byte 0x84 in position 31: invalid start byte
15:54:31.928 [ E ] python/python.cpp:209 call (PyObject_CallObject(<bound method ActionMap.action of <Components.ActionMap.ActionMap instance at 0x70691698>>,('WizardActions', 'info')) failed)
