### PR TITLE
Add epg search search scope

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -194,6 +194,7 @@ class EPGSearch(EPGSelection):
 				'red': (self.redButtonPressed, _('IMDB search for highlighted event')),
 				'green': (self.timerAdd, _('Add/remove/edit timer for highlighted event')),
 				'yellow': (self.yellowButtonPressed, _('Enter new search')),
+				'yellowlong': (self.showHistory, _('Show search history')),
 				'blue': (self.exportAutoTimer, _('Add an AutoTimer for highlighted event')),
 				'bluelong': (self.blueButtonPressedLong, _('Show AutoTimer list'))
 			}, -1)

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -183,38 +183,38 @@ class EPGSearch(EPGSelection):
 
 		self['okactions'] = HelpableActionMap(self, 'OkCancelActions',
 			{
-				'cancel': (self.closeScreen, _('Exit EPG')),
-				'OK': (self.epgsearchOK, _('Zap to channel (setup in menu)')),
-				'OKLong': (self.epgsearchOKLong, _('Zap to channel and close (setup in menu)'))
+				'cancel': (self.closeScreen, _('Exit EPG Search')),
+				'OK': (self.epgsearchOK, _('Zap to channel')),
+				'OKLong': (self.epgsearchOKLong, _('Show detailed event information'))
 			}, -1)
 		self['okactions'].csel = self
 
 		self['colouractions'] = HelpableActionMap(self, 'ColorActions', 
 			{
-				'red': (self.redButtonPressed, _('IMDB search for current event')),
-				'green': (self.timerAdd, _('Add/Remove timer for current event')),
-				'yellow': (self.yellowButtonPressed, _('Search for similar events')),
-				'blue': (self.exportAutoTimer, _('Add a auto timer for current event')),
-				'bluelong': (self.blueButtonPressed, _('Show AutoTimer List'))
+				'red': (self.redButtonPressed, _('IMDB search for highlighted event')),
+				'green': (self.timerAdd, _('Add/remove/edit timer for highlighted event')),
+				'yellow': (self.yellowButtonPressed, _('Enter new search')),
+				'blue': (self.exportAutoTimer, _('Add an AutoTimer for highlighted event')),
+				'bluelong': (self.blueButtonPressedLong, _('Show AutoTimer list'))
 			}, -1)
 		self['colouractions'].csel = self
 
 		self['recordingactions'] = HelpableActionMap(self, 'InfobarInstantRecord', 
 			{
-				'ShortRecord': (self.doRecordTimer, _('Add a record timer for current event')),
-				'LongRecord': (self.doZapTimer, _('Add a zap timer for current event'))
+				'ShortRecord': (self.doRecordTimer, _('Add a record timer for highlighted event')),
+				'LongRecord': (self.doZapTimer, _('Add a zap timer for highlighted event'))
 			}, -1)
 		self['recordingactions'].csel = self
 
 		self['epgactions'] = HelpableActionMap(self, 'EPGSelectActions', 
 			{
-				'nextBouquet': (self.nextBouquet, _('Goto next bouquet')),
-				'prevBouquet': (self.prevBouquet, _('Goto previous bouquet')),
-				'nextService': (self.nextService, _('Move down a page')),
-				'prevService': (self.prevService, _('Move up a page')),
-				'epg': (self.Info, _('Show detailed event info')),
-				'info': (self.Info, _('Show detailed event info')),
-				'infolong': (self.infoKeyPressed, _('Show single epg for current channel')),
+				'nextBouquet': (self.nextPage, _('Move down a page')),
+				'prevBouquet': (self.prevPage, _('Move up a page')),
+				'nextService': (self.prevPage, _('Move up a page')),
+				'prevService': (self.nextPage, _('Move down a page')),
+				'epg': (self.Info, _('Show detailed event information')),
+				'info': (self.Info, _('Show detailed event information')),
+				'infolong': (self.infoKeyPressed, _('Show detailed event information')),
 				'menu': (self.menu, _('Setup menu'))
 			}, -1)
 		self['epgactions'].csel = self
@@ -223,8 +223,8 @@ class EPGSearch(EPGSelection):
 			{
 				'left': (self.prevPage, _('Move up a page')),
 				'right': (self.nextPage, _('Move down a page')),
-				'up': (self.moveUp, _('Goto previous channel')),
-				'down': (self.moveDown, _('Goto next channel'))
+				'up': (self.moveUp, _('Move up')),
+				'down': (self.moveDown, _('Move down'))
 			}, -1)
 		self['epgcursoractions'].csel = self
 
@@ -399,6 +399,7 @@ class EPGSearch(EPGSelection):
 		self.session.openWithCallback(
 			self.menuCallback,
 			ChoiceBox,
+			title = _("EPG Search setup"),
 			list = options
 		)
 

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -51,6 +51,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		ConfigListScreen.__init__(
 			self,
 			[
+				getConfigListEntry(_("Search scope"), config.plugins.epgsearch.scope, _("Control where to search in the EPG. When 'all bouquets' is set, all bouquets are searched, even if 'Enable multiple bouquets' is disabled.")),
 				getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to be able to access the EPG-Search from within the plugin browser.")),
 				getConfigListEntry(_("Length of History"), config.plugins.epgsearch.history_length, _("How many entries to keep in the search history at most. 0 disables history entirely!")),
 				getConfigListEntry(_("Search Encoding"), config.plugins.epgsearch.encoding, _("Choose the encode type for search, helpful for foreign languages.")),

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -41,7 +41,6 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
 		self['footnote'] = Label("")
-		self["status"] = StaticText()
 
 		# Summary
 		self.setup_title = _("EPGSearch Setup")
@@ -72,12 +71,6 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		}, -2)
 		self["key_red"] = StaticText(_("Cancel"))
 		self["key_green"] = StaticText(_("OK"))
-		if not self.selectionChanged in self["config"].onSelectionChanged:
-			self["config"].onSelectionChanged.append(self.selectionChanged)
-		self.selectionChanged()
-
-	def selectionChanged(self):
-		self["status"].setText(self["config"].getCurrent()[2])
 
 	# for summary:
 	def changedEntry(self):

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -52,6 +52,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 			self,
 			[
 				getConfigListEntry(_("Search scope"), config.plugins.epgsearch.scope, _("Control where to search in the EPG. When 'all bouquets' is set, all bouquets are searched, even if 'Enable multiple bouquets' is disabled.")),
+				getConfigListEntry(_("Default scope when asked"), config.plugins.epgsearch.defaultscope, _("Sets the default search scope when the user is asked.")),
 				getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to be able to access the EPG-Search from within the plugin browser.")),
 				getConfigListEntry(_("Length of History"), config.plugins.epgsearch.history_length, _("How many entries to keep in the search history at most. 0 disables history entirely!")),
 				getConfigListEntry(_("Search Encoding"), config.plugins.epgsearch.encoding, _("Choose the encode type for search, helpful for foreign languages.")),

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -41,6 +41,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)
 		self['footnote'] = Label("")
+		self["description"] = Label()
 
 		# Summary
 		self.setup_title = _("EPGSearch Setup")

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -82,10 +82,10 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		if config.plugins.epgsearch.scope.value == "ask":
 			configList.append(getConfigListEntry(_("Default scope when asked"), config.plugins.epgsearch.defaultscope, _("Sets the default search scope when the user is asked.")))
 		configList += [
-			getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to be able to access the EPG-Search from within the plugin browser.")),
-			getConfigListEntry(_("Length of History"), config.plugins.epgsearch.history_length, _("How many entries to keep in the search history at most. 0 disables history entirely!")),
-			getConfigListEntry(_("Search Encoding"), config.plugins.epgsearch.encoding, _("Choose the encode type for search, helpful for foreign languages.")),
-# 				getConfigListEntry(_("Add \"Search\" Button to EPG"), config.plugins.epgsearch.add_search_to_epg , _("If this setting is enabled, the plugin adds a \"Search\" Button to the regular EPG.")),
+			getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to allow access to EPG Search from within the plugin browser.")),
+			getConfigListEntry(_("Length of history"), config.plugins.epgsearch.history_length, _("Maximum number of entries in the search history. Set this to 0 to disable search history.")),
+			getConfigListEntry(_("Search encoding"), config.plugins.epgsearch.encoding, _("Choose the encoding type for searches, helpful for foreign languages.")),
+# 				getConfigListEntry(_("Add \"Search\" button to EPG"), config.plugins.epgsearch.add_search_to_epg , _("If this setting is enabled, the plugin adds a \"Search\" button to the regular EPG.")),
 		]
 		self["config"].setList(configList)
 		if config.usage.sort_settings.value:

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -10,7 +10,8 @@ from Components.config import config, ConfigSet, ConfigSubsection, ConfigSelecti
 config.plugins.epgsearch = ConfigSubsection()
 config.plugins.epgsearch.showinplugins = ConfigYesNo(default = False)
 __searchDefaultScope = "currentbouquet" if getImageDistro() in ("easy-gui-aus", "beyonwiz") else "all"
-config.plugins.epgsearch.scope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service"))], default=__searchDefaultScope)
+config.plugins.epgsearch.scope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service")), ("ask", _("ask user"))], default=__searchDefaultScope)
+config.plugins.epgsearch.defaultscope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service"))], default=__searchDefaultScope)
 config.plugins.epgsearch.history = ConfigSet(choices = [])
 # XXX: configtext is more flexible but we cannot use this for a (not yet created) gui config
 config.plugins.epgsearch.encoding = ConfigSelection(choices = ['UTF-8', 'ISO8859-15'], default = 'UTF-8')

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from Components.Language import language
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS, SCOPE_LANGUAGE
+from boxbranding import getImageDistro
 import os, gettext
 
 # Config
@@ -8,6 +9,8 @@ from Components.config import config, ConfigSet, ConfigSubsection, ConfigSelecti
 
 config.plugins.epgsearch = ConfigSubsection()
 config.plugins.epgsearch.showinplugins = ConfigYesNo(default = False)
+__searchDefaultScope = "currentbouquet" if getImageDistro() in ("easy-gui-aus", "beyonwiz") else "all"
+config.plugins.epgsearch.scope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service"))], default=__searchDefaultScope)
 config.plugins.epgsearch.history = ConfigSet(choices = [])
 # XXX: configtext is more flexible but we cannot use this for a (not yet created) gui config
 config.plugins.epgsearch.encoding = ConfigSelection(choices = ['UTF-8', 'ISO8859-15'], default = 'UTF-8')


### PR DESCRIPTION
Add the ability for the user to specify the scope of the EPG search (all services/all bouquets/current bouquet/current service/ask user").

Fix bug that prevented setting description text from being displayed.

Tidied up `ActionMap` actions and help. Tidied up UI text.

Allow direct access to search history with long-YELLOW.

Detailed description of changes in the commit logs.

[EPGSearchSetup] Remove unused "status" widget

[EPGSearchSetup] Add "description" widget

EPG Search: Allow specification of search scope

EPG Search: Allow "ask user" specification of search scope

[EPGSearchSetup] Only show "ask user" specification of search scope when active

EPG Search: ActionMap and text cleanup

[EPGSearch] Add search history access on long-YELLOW