### PR TITLE
Epgsearch searchscope fixup

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -143,7 +143,7 @@ class EPGSearch(EPGSelection):
 
 	def __init__(self, session, *args):
 		Screen.__init__(self, session)
-		self.skinName = ["EPGSearch", "EPGSelection"]
+		self.skinName = [self.skinName, "EPGSelection"]
 		HelpableScreen.__init__(self)
 
 		self.searchargs = args
@@ -634,7 +634,7 @@ class EPGSearch(EPGSelection):
 class EPGSearchTimerImport(Screen):
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		self.skinName = ["EPGSearchTimerImport", "TimerEditList"]
+		self.skinName = [self.skinName, "TimerEditList"]
 
 		self.list = []
 		self.fillTimerList()
@@ -680,7 +680,7 @@ class EPGSearchTimerImport(Screen):
 class EPGSearchChannelSelection(SimpleChannelSelection):
 	def __init__(self, session):
 		SimpleChannelSelection.__init__(self, session, _("Channel Selection"))
-		self.skinName = ["EPGSearchChannelSelection", "SimpleChannelSelection"]
+		self.skinName = [self.skinName, "SimpleChannelSelection"]
 
 		self["ChannelSelectEPGActions"] = ActionMap(["ChannelSelectEPGActions"],
 		{
@@ -706,7 +706,7 @@ class EPGSearchChannelSelection(SimpleChannelSelection):
 class EPGSearchEPGSelection(EPGSelection):
 	def __init__(self, session, ref, openPlugin):
 		EPGSelection.__init__(self, session, ref)
-		self.skinName = ["EPGSearchEPGSelection", "EPGSelection"]
+		self.skinName = [self.skinName, "EPGSelection"]
 		self["key_green"].text = _("Search")
 		self.openPlugin = openPlugin
 

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -73,7 +73,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 
 	def clearNotifiers(self):
 		for n in self.notifiers:
-			n.removeNotifier(self.updateConfig, initial_call=False)
+			n.removeNotifier(self.updateConfig)
 
 	def createConfig(self):
 		configList = [

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -36,7 +36,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 
 	def __init__(self, session):
 		Screen.__init__(self, session)
-		self.skinName = "Setup"
+		self.skinName = [self.skinName, "Setup"]
 		self["HelpWindow"] = Pixmap()
 		self["HelpWindow"].hide()
 		self["VKeyIcon"] = Boolean(False)


### PR DESCRIPTION
A crash fix, tweak flag handling to ignore irrelevant flags, make skin name lists in `EPGSearch` re-user the skin name already set in the class, and add the ability to override the Setup skin in `EPGSearchSetup`.

Also add "Setup" entry to "ask user" search scope menu to allow the user to modify oter search settings before running the search.

These changes were intended to have been in add-epgsearch-searchscope.