### PR TITLE
EPG Search: Add optional orbital position to search list

### DIFF
--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -1,5 +1,5 @@
 # for localized messages
-from . import _
+from . import _, allowShowOrbital
 
 # GUI (Screens)
 from Screens.Screen import Screen
@@ -81,6 +81,8 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		]
 		if config.plugins.epgsearch.scope.value == "ask":
 			configList.append(getConfigListEntry(_("Default scope when asked"), config.plugins.epgsearch.defaultscope, _("Sets the default search scope when the user is asked.")))
+		if allowShowOrbital:
+			configList.append(getConfigListEntry(_("Show orbital position"), config.plugins.epgsearch.showorbital, _("Show satellite orbital positions in the search results.")))
 		configList += [
 			getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to allow access to EPG Search from within the plugin browser.")),
 			getConfigListEntry(_("Length of history"), config.plugins.epgsearch.history_length, _("Maximum number of entries in the search history. Set this to 0 to disable search history.")),

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -12,6 +12,8 @@ config.plugins.epgsearch.showinplugins = ConfigYesNo(default = False)
 __searchDefaultScope = "currentbouquet" if getImageDistro() in ("easy-gui-aus", "beyonwiz") else "all"
 config.plugins.epgsearch.scope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service")), ("ask", _("ask user"))], default=__searchDefaultScope)
 config.plugins.epgsearch.defaultscope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service"))], default=__searchDefaultScope)
+allowShowOrbital = getImageDistro() not in ("easy-gui-aus", "beyonwiz")
+config.plugins.epgsearch.showorbital = ConfigYesNo(default = allowShowOrbital)
 config.plugins.epgsearch.history = ConfigSet(choices = [])
 # XXX: configtext is more flexible but we cannot use this for a (not yet created) gui config
 config.plugins.epgsearch.encoding = ConfigSelection(choices = ['UTF-8', 'ISO8859-15'], default = 'UTF-8')


### PR DESCRIPTION
Optionally add an orbital position to each search result.

Code cleanup to simplify `EPGSearchList`.

Allow AutoTimer icons to be displayed if `EPGList` supports their display.
