### PR TITLE
Add search type/case sensitivity settings and IceTV timer icons

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -92,6 +92,9 @@ class EPGSearchList(EPGList):
 			pics.append(self.clocks[clock_pic])
 		if getattr(self, "wasEntryAutoTimer", False) and hasattr(self, "autotimericon"):
 			pics.append(self.autotimericon)
+		# Timer icons for timers set by IceTV (icetv.com.au)
+		if getattr(self, "wasEntryIceTV", False) and hasattr(self, "icetvicon"):
+			pics.append(self.icetvicon)
 
 		if self.screenwidth and self.screenwidth == 1920:
 			picx = 25

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -84,6 +84,8 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		if allowShowOrbital:
 			configList.append(getConfigListEntry(_("Show orbital position"), config.plugins.epgsearch.showorbital, _("Show satellite orbital positions in the search results.")))
 		configList += [
+			getConfigListEntry(_("Search type"), config.plugins.epgsearch.search_type, _("Set type of match used to compare program titles with the search string")),
+			getConfigListEntry(_("Search strictness"), config.plugins.epgsearch.search_case, _("Is the search case-sensitive or case-insensitive")),
 			getConfigListEntry(_("Show in plugin browser"), config.plugins.epgsearch.showinplugins, _("Enable this to allow access to EPG Search from within the plugin browser.")),
 			getConfigListEntry(_("Length of history"), config.plugins.epgsearch.history_length, _("Maximum number of entries in the search history. Set this to 0 to disable search history.")),
 			getConfigListEntry(_("Search encoding"), config.plugins.epgsearch.encoding, _("Choose the encoding type for searches, helpful for foreign languages.")),

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -12,6 +12,8 @@ config.plugins.epgsearch.showinplugins = ConfigYesNo(default = False)
 __searchDefaultScope = "currentbouquet" if getImageDistro() in ("easy-gui-aus", "beyonwiz") else "all"
 config.plugins.epgsearch.scope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service")), ("ask", _("ask user"))], default=__searchDefaultScope)
 config.plugins.epgsearch.defaultscope = ConfigSelection(choices=[("all", _("all services")), ("allbouquets", _("all bouquets")), ("currentbouquet", _("current bouquet")), ("currentservice", _("current service"))], default=__searchDefaultScope)
+config.plugins.epgsearch.search_type = ConfigSelection(default = "partial", choices = [("partial", _("partial match")), ("exact", _("exact match")), ("start", _("title starts with"))])
+config.plugins.epgsearch.search_case = ConfigSelection(default = "insensitive", choices = [("insensitive", _("case-insensitive search")), ("sensitive", _("case-sensitive search"))])
 allowShowOrbital = getImageDistro() not in ("easy-gui-aus", "beyonwiz")
 config.plugins.epgsearch.showorbital = ConfigYesNo(default = allowShowOrbital)
 config.plugins.epgsearch.history = ConfigSet(choices = [])


### PR DESCRIPTION
Add code to set the eEPGCache.search() search type and search case
sensitivity from settings.

Displays the IceTV logo for timers set by IceTV, if the implementation of EPGList supports them.
