### PR TITLE
EPG Search: Allow optional search from search history at startup

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -164,7 +164,7 @@ class EPGSearch(EPGSelection):
 	def firstSearch(self):
 	        return hasattr(self, "searchargs")
 
-	def __init__(self, session, *args):
+	def __init__(self, session, *args, **kwargs):
 		Screen.__init__(self, session)
 		self.skinName = [self.skinName, "EPGSelection"]
 		HelpableScreen.__init__(self)
@@ -256,6 +256,8 @@ class EPGSearch(EPGSelection):
 			}, -1)
 		self['epgcursoractions'].csel = self
 
+		self.openHistory = kwargs.get("openHistory", False)
+
 		self.onLayoutFinish.append(self.onCreate)
 		# end stripped copy of EPGSelection.__init__
 
@@ -297,6 +299,9 @@ class EPGSearch(EPGSelection):
 
 	def refreshlist(self):
 		self.refreshTimer.stop()
+		if self.firstSearch and self.openHistory:
+			self.showHistory()
+			return
 		if self.firstSearch and self.searchargs:
 			self.searchEPG(*self.searchargs)
 		elif self.currSearch:

--- a/epgsearch/src/plugin.py
+++ b/epgsearch/src/plugin.py
@@ -43,6 +43,9 @@ def eventinfo(session, eventName="", **kwargs):
 			eventName = event and event.getEventName() or ''
 	session.open(EPGSearch, eventName)
 
+def seachhistory(session, *args, **kwargs):
+	session.open(EPGSearch, openHistory=True)
+
 # Movielist
 def movielist(session, service, **kwargs):
 	serviceHandler = eServiceCenter.getInstance()
@@ -55,10 +58,19 @@ pluginlist = PluginDescriptor(name = _("EPGSearch"), description = _("Search EPG
 def Plugins(**kwargs):
 	l = [
 		PluginDescriptor(
-			# TRANSLATORS: EPGSearch title in EventInfo dialog (requires the user to select an event to search for)
-			name = _("search EPG..."),
+			# TRANSLATORS: EPGSearch title in EventInfo dialog (does not require further user interaction)
+			# TRANSLATORS: \0x86 is non-printing and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it as the first character in translations.
+			name = _("\x86search EPG"),
 			where = PluginDescriptor.WHERE_EVENTINFO,
 			fnc = eventinfo,
+			needsRestart = False,
+		),
+		PluginDescriptor(
+			# TRANSLATORS: EPGSearch search from search history in EventInfo dialog (requires the user to select a history item to search for)
+			# TRANSLATORS: \0x87 is non-printing and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it as the first character in translations.
+			name = _("\x87search EPG from history..."),
+			where = PluginDescriptor.WHERE_EVENTINFO,
+			fnc = seachhistory,
 			needsRestart = False,
 		),
 		PluginDescriptor(
@@ -66,6 +78,13 @@ def Plugins(**kwargs):
 			description = _("search EPG"),
 			where = PluginDescriptor.WHERE_MOVIELIST,
 			fnc = movielist,
+			needsRestart = False,
+		),
+		PluginDescriptor(
+			# TRANSLATORS: EPGSearch search from search history in MovieList (requires the user to select a history item to search for)
+			description = _("search EPG from history..."),
+			where = PluginDescriptor.WHERE_MOVIELIST,
+			fnc = seachhistory,
 			needsRestart = False,
 		),
 	]


### PR DESCRIPTION
[EPGSearch]

Add default parameter openHistory to __init__(). Defautls to False.
When True, EPGSearch opens the EPG Search History popup to allow
search from the history instead of initiating an immediate search.

[plugin]

Add searchhistory() function for calling from PluginDescriptors to
allow startup in the EPG Search History popup.

Add PluginDescriptors to call the searchhistory() function from the
Event Info popups from live TV and from Screens.ButtonSetup
(WHERE_EVENTINFO), and from the MENU button in Screens.MovieSelection
(WHERE_MOVIELIST).

In Screens.ButtonSetup, the normal "search EPG" can be referenced
as "Plugins/Extensions/EPGSearch/1" and "search EPG from history..."
can be referenced as "Plugins/Extensions/EPGSearch/2".

Add non-printing characters "\x86" and "\x87" to the start of the
PluginDescriptor names "search EPG" and "search EPG from history..."
so that when descriptors are sorted by name in Screens.ButtonSetup,
they retain their order of "/1" and "/2" in
Screens.ButtonSetup.ButtonSetupKeys.

Add translators notes about the use of "\x86" and "\x87", so that
translators leave these sort characters at the beginning of translated
strings.

Correct other translators notes to reflect what the PluginDescriptors
do.