### PR TITLE
[epgsearch] Redisplay search list after orbpos setting changes

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -514,6 +514,7 @@ class EPGSearch(EPGSelection):
 			config.plugins.epgsearch.scope.value,
 			config.plugins.epgsearch.search_type.value,
 			config.plugins.epgsearch.search_case.value,
+			allowShowOrbital and config.plugins.epgsearch.showorbital.value,
 		)
 
 	def setup(self):


### PR DESCRIPTION
Redisplay the list after the "Show orbital position" setting
changes, so that the change is reflected in the search list immediately.