### PR TITLE
[epgsearch] Tweak ordering of translated strings

### DIFF
--- a/epgsearch/src/plugin.py
+++ b/epgsearch/src/plugin.py
@@ -59,16 +59,16 @@ def Plugins(**kwargs):
 	l = [
 		PluginDescriptor(
 			# TRANSLATORS: EPGSearch title in EventInfo dialog (does not require further user interaction)
-			# TRANSLATORS: \0x86 is non-printing and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it as the first character in translations.
-			name = _("\x86search EPG"),
+			# TRANSLATORS: %s inserts a non-printing character and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it at the start of the translation string.
+			name = _("%ssearch EPG") % "\x86",
 			where = PluginDescriptor.WHERE_EVENTINFO,
 			fnc = eventinfo,
 			needsRestart = False,
 		),
 		PluginDescriptor(
 			# TRANSLATORS: EPGSearch search from search history in EventInfo dialog (requires the user to select a history item to search for)
-			# TRANSLATORS: \0x87 is non-printing and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it as the first character in translations.
-			name = _("\x87search EPG from history..."),
+			# TRANSLATORS: %s inserts a non-printing character and is only used to control the sort order of these WHERE_EVENTINFO entries in Screens.ButtonSetup. Please leave it at the start of the translation string.
+			name = _("%ssearch EPG from history...") % "\x87",
 			where = PluginDescriptor.WHERE_EVENTINFO,
 			fnc = seachhistory,
 			needsRestart = False,


### PR DESCRIPTION
Replace the use of "\x86" / "\x87" to control the sort ordet of plugins,
because they don't seem to work in translations.

Use _("%sTranslated String) % "\x86" in the code instead: printf format
codes should work better.