### PR TITLE
Epgsearch misc fixes

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -118,7 +118,7 @@ class EPGSearchList(EPGList):
 			(eListboxPythonMultiContent.TYPE_TEXT, r2.x, r2.y, r2.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, strftime("%e/%m, %H:%M", t))
 		]
 		if r3.w:
-			res.append((eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, r3.w, r1.h, 0, RT_HALIGN_RIGHT|RT_VALIGN_CENTER, self.getOrbitalPos(serviceref)))
+			res.append((eListboxPythonMultiContent.TYPE_TEXT, r3.x, r3.y, r3.w, r1.h, 0, RT_HALIGN_LEFT|RT_VALIGN_CENTER, self.getOrbitalPos(serviceref)))
 		picwidth = 0
 		for pic in pics:
 			picwidth += picx
@@ -134,15 +134,13 @@ class EPGSearchList(EPGList):
 		width = self.descr_rect.x + self.descr_rect.w
 		if allowShowOrbital and config.plugins.epgsearch.showorbital.value:
 			fontSize = self.eventFontSizeSingle + config.epgselection.enhanced_eventfs.value
-			orbitalPosWidth = int(fontSize * 4.2)
-			orbitalPosSpace = int(fontSize * 0.5)
+			orbitalPosWidth = int(fontSize * 4.4)
 		else:
 			orbitalPosWidth = 0
-			orbitalPosSpace = 0
 
 		self.orbpos_rect = Rect(self.descr_rect.x, self.descr_rect.y, orbitalPosWidth, self.descr_rect.h)
 		orbpos_r = self.orbpos_rect.x + self.orbpos_rect.w
-		self.descr_rect = Rect(orbpos_r + orbitalPosSpace, self.orbpos_rect.y, width - orbpos_r - orbitalPosSpace, self.orbpos_rect.h)
+		self.descr_rect = Rect(orbpos_r, self.orbpos_rect.y, width - orbpos_r, self.orbpos_rect.h)
 
 	def getOrbitalPos(self, ref):
 		refstr = None

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -53,7 +53,6 @@ try:
 except ImportError:
 	autoTimerAvailable = False
 
-service_types_tv = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 22) || (type == 25) || (type == 134) || (type == 195)'
 rootbouquet_tv = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.tv" ORDER BY bouquet'
 rootbouquet_radio = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.radio" ORDER BY bouquet'
 
@@ -369,12 +368,12 @@ class EPGSearch(EPGSelection):
 			return False
 
 		ChannelSelectionInstance = ChannelSelection.instance
-		self.service_types = service_types_tv
 		foundService = False
 		if ChannelSelectionInstance:
+			self.service_types = ChannelSelectionInstance.service_types
 			serviceHandler = eServiceCenter.getInstance()
+			bqrootstr = ChannelSelectionInstance.bouquet_rootstr
 			if config.usage.multibouquet.value:
-				bqrootstr = rootbouquet_tv
 				rootbouquet = eServiceReference(bqrootstr)
 				currentBouquet = ChannelSelectionInstance.getRoot()
 				for searchCurrent in (True, False):
@@ -393,7 +392,6 @@ class EPGSearch(EPGSelection):
 						if foundService:
 							break
 			else:
-				bqrootstr = '%s FROM BOUQUET "userbouquet.favourites.tv" ORDER BY bouquet'%(self.service_types)
 				rootbouquet = eServiceReference(bqrootstr)
 				bouquet = eServiceReference(bqrootstr)
 				if bouquet.valid() and bouquet.flags & (eServiceReference.isDirectory | eServiceReference.isInvisible) == eServiceReference.isDirectory:

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -11,7 +11,7 @@ from ServiceReference import ServiceReference
 
 from EPGSearchSetup import EPGSearchSetup
 from Screens.InfoBar import MoviePlayer
-from Screens.ChannelSelection import ChannelSelection, SimpleChannelSelection
+from Screens.ChannelSelection import ChannelSelection, SimpleChannelSelection, MODE_RADIO
 from Screens.ChoiceBox import ChoiceBox
 from Screens.EpgSelection import EPGSelection
 from Screens.MessageBox import MessageBox
@@ -55,6 +55,7 @@ except ImportError:
 
 service_types_tv = '1:7:1:0:0:0:0:0:0:0:(type == 1) || (type == 17) || (type == 22) || (type == 25) || (type == 134) || (type == 195)'
 rootbouquet_tv = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.tv" ORDER BY bouquet'
+rootbouquet_radio = '1:7:1:0:0:0:0:0:0:0:FROM BOUQUET "bouquets.radio" ORDER BY bouquet'
 
 # Modified EPGSearchList with support for PartnerBox
 class EPGSearchList(EPGList):
@@ -692,7 +693,11 @@ class EPGSearch(EPGSelection):
 
 	def allBouquetServiceRefSet(self):
 		serviceHandler = eServiceCenter.getInstance()
-		bqrootstr = rootbouquet_tv
+		ChannelSelectionInstance = ChannelSelection.instance
+		if ChannelSelectionInstance and ChannelSelectionInstance.mode == MODE_RADIO:
+			bqrootstr = rootbouquet_radio
+		else:
+			bqrootstr = rootbouquet_tv
 		rootbouquet = eServiceReference(bqrootstr)
 		bouquetlist = serviceHandler.list(rootbouquet)
 		serviceRefSet = set()
@@ -705,9 +710,11 @@ class EPGSearch(EPGSelection):
 		return serviceRefSet
 
 	def currentBouquetServiceRefSet(self):
-		bouquet = ChannelSelection.instance.getRoot()
 		serviceRefSet = set()
-		self._addBouquetServices(bouquet, serviceRefSet)
+		ChannelSelectionInstance = ChannelSelection.instance
+		if ChannelSelectionInstance:
+			bouquet = ChannelSelectionInstance.getRoot()
+			self._addBouquetServices(bouquet, serviceRefSet)
 		return serviceRefSet
 
 	def currentServiceServiceRefSet(self):

--- a/epgsearch/src/plugin.py
+++ b/epgsearch/src/plugin.py
@@ -75,6 +75,7 @@ def Plugins(**kwargs):
 		),
 		PluginDescriptor(
 			# TRANSLATORS: EPGSearch title in MovieList (does not require further user interaction)
+			name = _("search EPG"),
 			description = _("search EPG"),
 			where = PluginDescriptor.WHERE_MOVIELIST,
 			fnc = movielist,
@@ -82,6 +83,7 @@ def Plugins(**kwargs):
 		),
 		PluginDescriptor(
 			# TRANSLATORS: EPGSearch search from search history in MovieList (requires the user to select a history item to search for)
+			name = _("search EPG from history..."),
 			description = _("search EPG from history..."),
 			where = PluginDescriptor.WHERE_MOVIELIST,
 			fnc = seachhistory,


### PR DESCRIPTION
[epgsearch] Make searches more comprehensive and accurate

Search the EPG on serviceref and then filter on the search string to
preserve path and name information in the servicerefs searched on.

Path and name information is lost when eEPGCache::search() is
used for the search.

Change the "all services" search so that it searches all the
servicerefs in "all bouquets" as well as the servicerefs in lamedb.

[epgsearch] Search TV bouquets in TV mode and Radio bouquets in Radio mode

Also make code robust to ChannelSelection.instance not being set.

[epgsearch] Make orbpos column left-adjusted

Also slightly wider to accommodate a VIX skin.

[epgsearch] Make zap() work correctly in Radio mode

[epgsearch] Fix button assignment in MovieSelection

Allow both WHERE_MOVIELIST PluginDescriptors to appear
in button bindings in MovieSelection by giving them distinct
names.
