### PR TITLE
Filter searches by orbpos/source & fix history trimming

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -534,6 +534,8 @@ class EPGSearch(EPGSelection):
 		del self.__reSearchSettings
 
 	def showHistory(self):
+		self._trimHistory()
+
 		options = [(x, x) for x in config.plugins.epgsearch.history.value]
 
 		if options:
@@ -550,6 +552,12 @@ class EPGSearch(EPGSelection):
 				type = MessageBox.TYPE_INFO
 			)
 
+	def _trimHistory(self):
+		history = config.plugins.epgsearch.history.value
+		maxLen = config.plugins.epgsearch.history_length.value
+		if len(history) > maxLen:
+			del history[maxLen:]
+
 	def searchEPGWrapper(self, ret):
 		if ret:
 			self.searchEPG(ret[1])
@@ -561,12 +569,11 @@ class EPGSearch(EPGSelection):
 				history = config.plugins.epgsearch.history.value
 				if searchString not in history:
 					history.insert(0, searchString)
-					maxLen = config.plugins.epgsearch.history_length.value
-					if len(history) > maxLen:
-						del history[maxLen:]
+					self._trimHistory()
 				else:
 					history.remove(searchString)
 					history.insert(0, searchString)
+
 			if config.plugins.epgsearch.scope.value == "ask" and lastAsk is None:
 				list = [
 					(_("All services"), "all"),

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -1,5 +1,5 @@
 # for localized messages
-from . import _, allowShowOrbital
+from . import _, allowShowOrbital, getOrbposConfList
 
 from enigma import eEPGCache, eTimer, eServiceReference, eServiceCenter, RT_HALIGN_LEFT, RT_HALIGN_RIGHT, RT_VALIGN_CENTER, eListboxPythonMultiContent, getDesktop, getBestPlayableServiceReference
 import NavigationInstance
@@ -293,7 +293,6 @@ class EPGSearch(EPGSelection):
 					"showRadio": self.showTrailerList,
 					"startTeletext": self.showConfig
 				})
-
 	def onCreate(self):
 		self.setTitle(_("EPG Search"))
 
@@ -513,8 +512,11 @@ class EPGSearch(EPGSelection):
 			config.plugins.epgsearch.scope.value,
 			config.plugins.epgsearch.search_type.value,
 			config.plugins.epgsearch.search_case.value,
+			config.plugins.epgsearch.enableorbpos.value,
+			config.plugins.epgsearch.invertorbpos.value,
 			allowShowOrbital and config.plugins.epgsearch.showorbital.value,
-		)
+		) + tuple(set((orbposItem.orbital_position for orbposItem in getOrbposConfList())))
+
 
 	def setup(self):
 		self.__reSearchSettings = self.getReSearchSetings()
@@ -657,7 +659,7 @@ class EPGSearch(EPGSelection):
 			caseMatchFunc = lambda s: matchFunc(s.lower())
 
 		ret = []
-		for sref in searchFilter:
+		for sref in self._sourceFilter(searchFilter):
 			lookup = [args, (sref, 0, 0, -1)]
 			# Enumerate EPG for service, defaulting to empty list
 			# and apply search, accumulating results
@@ -718,6 +720,23 @@ class EPGSearch(EPGSelection):
 		if not service or not service.valid:
 			return None
 		return { service.toString() }
+
+	def _sourceFilter(self, serviceRefSet):
+		if not config.plugins.epgsearch.enableorbpos.value:
+			return serviceRefSet
+
+		filtSet = set((orbposItem.orbital_position << 16 for orbposItem in getOrbposConfList()))
+
+		if not filtSet:
+			return serviceRefSet
+
+		filtServiceRefSet = set()
+		include = config.plugins.epgsearch.invertorbpos.value == _("include")
+		for srefstr in serviceRefSet:
+			sref = eServiceReference(srefstr)
+			if (sref.getUnsignedData(4) in filtSet) == include:
+				filtServiceRefSet.add(srefstr)
+		return filtServiceRefSet
 
 class EPGSearchTimerImport(Screen):
 	def __init__(self, session):

--- a/epgsearch/src/EPGSearchSetup.py
+++ b/epgsearch/src/EPGSearchSetup.py
@@ -1,5 +1,5 @@
 # for localized messages
-from . import _, allowShowOrbital
+from . import _, allowShowOrbital, updateOrbposConfig, purgeOrbposConfig, getOrbposConfList, orbposChoicelist
 
 # GUI (Screens)
 from Screens.Screen import Screen
@@ -19,9 +19,12 @@ from Components.Sources.Boolean import Boolean
 from Components.config import config, getConfigListEntry
 from Components.PluginComponent import plugins
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS
+from Tools.BoundFunction import boundFunction
 
 # Plugin definition
 from Plugins.Plugin import PluginDescriptor
+
+from collections import defaultdict
 
 class EPGSearchSetup(Screen, ConfigListScreen):
 	skin = """<screen name="EPGSearchSetup" position="center,center" size="565,370">
@@ -49,10 +52,16 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		self.onChangedEntry = []
 
 		ConfigListScreen.__init__(self, [], session = session, on_change = self.changedEntry)
-		self.createConfig()
 		self.notifiers = (
 			config.plugins.epgsearch.scope,
+			config.plugins.epgsearch.enableorbpos,
+			config.plugins.epgsearch.invertorbpos,
+			config.plugins.epgsearch.numorbpos,
 		)
+		nChoices = updateOrbposConfig(save=True)
+		if nChoices <= 2:
+			config.plugins.epgsearch.enableorbpos.value = False
+		self.createConfig()
 		self.addNotifiers()
 		self.onClose.append(self.clearNotifiers)
 
@@ -91,6 +100,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 			getConfigListEntry(_("Search encoding"), config.plugins.epgsearch.encoding, _("Choose the encoding type for searches, helpful for foreign languages.")),
 # 				getConfigListEntry(_("Add \"Search\" button to EPG"), config.plugins.epgsearch.add_search_to_epg , _("If this setting is enabled, the plugin adds a \"Search\" button to the regular EPG.")),
 		]
+		configList += self.createOrbposConfig()
 		self["config"].setList(configList)
 		if config.usage.sort_settings.value:
 			self["config"].list.sort()
@@ -111,6 +121,7 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		return SetupSummary
 
 	def save(self):
+		purgeOrbposConfig()
 		self.saveAll()
 		if not config.plugins.epgsearch.showinplugins.value:
 			for plugin in plugins.getPlugins(PluginDescriptor.WHERE_PLUGINMENU):
@@ -120,10 +131,33 @@ class EPGSearchSetup(Screen, ConfigListScreen):
 		plugins.readPluginList(resolveFilename(SCOPE_PLUGINS))
 		self.close()
 
+	def createOrbposConfig(self):
+		# Only show source/orbpos choices if there is more than
+		# one choice (not including "disabled")
+		nChoices = updateOrbposConfig()
+		if nChoices > 2:
+			configList = [getConfigListEntry(_("Filter results by source"), config.plugins.epgsearch.enableorbpos, _("Include or exclude results depending on their source (e.g. by satellite)"))]
+			if config.plugins.epgsearch.enableorbpos.value:
+				configList += [
+					getConfigListEntry(_("Include/exclude sources"), config.plugins.epgsearch.invertorbpos, _("Use source restrictions below to only include results from the sources, or exclude them.")),
+					getConfigListEntry(_("Number of inclusions/exclusions"), config.plugins.epgsearch.numorbpos, _("Number of filters for inclusion/exclusion of results")),
+				]
+				if config.plugins.epgsearch.invertorbpos.value == _("include"):
+					restrictionName = _("Include results from")
+				else:
+					restrictionName = _("Exclude results from")
+				restrictionDesc = _("Include/exclude search results from this type of source")
+				configList += [
+					getConfigListEntry(restrictionName, confItem, restrictionDesc)
+					for confItem in getOrbposConfList(includeDisabled=True)
+				]
+		else:
+			configList = []
+		return configList
+
+
 	def cancel(self):
-		for x in self["config"].list:
-			x[1].cancel()
-		self.close(False)
+		self.keyCancel()
 
 	def createSummary(self):
 		return SetupSummary

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 from Components.Language import language
+from Components.NimManager import nimmanager
 from Tools.Directories import resolveFilename, SCOPE_PLUGINS, SCOPE_LANGUAGE
 from boxbranding import getImageDistro
+from enigma import eServiceReference, eServiceCenter
 import os, gettext
 
 # Config
-from Components.config import config, ConfigSet, ConfigSubsection, ConfigSelection, ConfigNumber, ConfigYesNo
+from Components.config import config, configfile, ConfigSet, ConfigSubsection, ConfigSelection, ConfigNumber, ConfigYesNo, ConfigSatlist
 
 PluginLanguageDomain = "EPGSearch"
 PluginLanguagePath = "Extensions/EPGSearch/locale"
@@ -36,3 +38,147 @@ config.plugins.epgsearch.history = ConfigSet(choices = [])
 config.plugins.epgsearch.encoding = ConfigSelection(choices = ['UTF-8', 'ISO8859-15'], default = 'UTF-8')
 config.plugins.epgsearch.history_length = ConfigNumber(default = 10)
 config.plugins.epgsearch.add_search_to_epg = ConfigYesNo(default = True)
+
+orbposDisabled = 3600
+
+def getNamespaces(namespaces):
+	lamedbServices = eServiceReference("1:7:1:0:0:0:0:0:0:0:" + " || ".join(map(lambda x: '(satellitePosition == %d)' % (x >> 16), namespaces)))
+	hasNamespaces = set()
+	if not namespaces:
+		return hasNamespaces
+	serviceHandler = eServiceCenter.getInstance()
+	servicelist = serviceHandler.list(lamedbServices)
+	if servicelist is not None:
+		serviceIterator = servicelist.getNext()
+		while serviceIterator.valid():
+			ns = serviceIterator.getUnsignedData(4)
+			if ns not in hasNamespaces and ns in namespaces:
+				hasNamespaces.add(ns)
+				if len(hasNamespaces) == len(namespaces):
+					return hasNamespaces
+			serviceIterator = servicelist.getNext()
+	return hasNamespaces
+
+def orbposChoicelist():
+	choiceList = [(orbposDisabled, _('disabled'), 0)]
+	nsDVBT = 0xeeee << 16
+	nsDVBC = 0xffff << 16
+	namespaces = set()
+	if nimmanager.hasNimType("DVB-T") and nimmanager.terrestrialsList:
+		namespaces.add(nsDVBT)
+	if nimmanager.hasNimType("DVB-C") and nimmanager.cablesList:
+		namespaces.add(nsDVBC)
+	hasNamespaces = getNamespaces(namespaces)
+	if nsDVBT in hasNamespaces:
+		choiceList.append((nsDVBT >> 16, _('DVB-T Terrestrial services'), 0))
+	if nsDVBC in hasNamespaces:
+		choiceList.append((nsDVBC >> 16, _('DVB-C Cable services'), 0))
+	choiceList += [
+		(orbpos, nimmanager.getSatDescription(orbpos), 0)
+		for orbpos in sorted(
+			nimmanager.getConfiguredSats(),
+			key=lambda x: x if x <= 1800 else x - 3600
+		)
+	]
+	return choiceList
+
+def isOrbposName(name):
+	return name.startswith("orbpos") and name[6:].isdigit()
+
+def doSave():
+	saveFile = False
+	for name, confItem in config.plugins.epgsearch.dict().iteritems():
+		if (name == "numorbpos" or isOrbposName(name)) and confItem.isChanged():
+			saveFile = True
+			confItem.save()
+	if saveFile:
+		configfile.save()
+
+def unusedOrbPosConfList():
+	numorbpos = int(config.plugins.epgsearch.numorbpos.value)
+	return [
+		item for item in config.plugins.epgsearch.dict().iteritems()
+		if isOrbposName(item[0]) and int(item[0][6:]) >= numorbpos
+	]
+
+def initOrbposConfigs():
+	choiceList = orbposChoicelist()
+	maxEntries = len(choiceList)
+	oldVal = config.plugins.epgsearch.getSavedValue().get('numorbpos')
+	listShrank = oldVal is not None and int(oldVal) > maxEntries
+	choices = [str(i) for i in range(maxEntries + 1)]
+	config.plugins.epgsearch.numorbpos = ConfigSelection(choices, default="1")
+	if listShrank:
+		config.plugins.epgsearch.numorbpos.value = str(maxEntries)
+
+	# If the list got smaller, try to preserve the values of as
+	# many entries as possible in the new list.
+	orbPosList = []
+	for name in (name for name in config.plugins.epgsearch.getSavedValue().keys() if isOrbposName(name)):
+		setattr(config.plugins.epgsearch, name, ConfigSatlist(choiceList, default=orbposDisabled))
+		if listShrank:
+			orbPosList.append((getattr(config.plugins.epgsearch, name), int(name[6:])))
+	if orbPosList:
+		orbPosList.sort(key=lambda x: x[1])
+		orbPosList.sort(key=lambda x: int(x[0].value) == orbposDisabled)
+		for i in range(min(maxEntries, len(orbPosList))):
+			getattr(config.plugins.epgsearch, "orbpos" + str(i)).value = orbPosList[i][0].value
+
+def updateOrbposConfig(save=False):
+	choiceList = orbposChoicelist()
+	updateNumOrbpos(choiceList, save)
+	setChoiceList = None
+	# Add any new items & update any existing ones
+	for filt in range(int(config.plugins.epgsearch.numorbpos.value)):
+		name = "orbpos" + str(filt)
+		if hasattr(config.plugins.epgsearch, name):
+			if setChoiceList is None:
+				setChoiceList = [(str(orbpos), desc) for (orbpos, desc, flags) in choiceList]
+			confItem = getattr(config.plugins.epgsearch, name)
+			confItem.setChoices(setChoiceList, default=str(orbposDisabled))
+		else:
+			setattr(config.plugins.epgsearch, name, ConfigSatlist(choiceList, default=orbposDisabled))
+	if save:
+		doSave()
+	return len(choiceList)
+
+# Set old items to default so that they will disappear from the settings file
+def purgeOrbposConfig():
+	for name, confItem in unusedOrbPosConfList():
+		if confItem.value != confItem.default:
+			confItem.value = confItem.default
+	doSave()
+
+def updateUnusedOrbposConfig(choiceList, save):
+	setChoiceList = [(str(orbpos), desc) for (orbpos, desc, flags) in choiceList]
+	for name, confItem in unusedOrbPosConfList():
+		confItem.setChoices(setChoiceList, default=str(orbposDisabled))
+	if save:
+		doSave()
+
+def getOrbposConfList(includeDisabled=False):
+	return [
+		getattr(config.plugins.epgsearch, "orbpos" + str(filt))
+		for filt in range(int(config.plugins.epgsearch.numorbpos.value))
+		if (
+			includeDisabled or
+			getattr(config.plugins.epgsearch, "orbpos" + str(filt)).orbital_position != orbposDisabled
+		)
+	]
+
+def updateNumOrbpos(choiceList, save):
+	maxEntries = max(len(choiceList) - 1, 0)
+	oldVal = int(config.plugins.epgsearch.numorbpos.value)
+	choices = [str(i) for i in range(maxEntries + 1)]
+	oldMax = len(config.plugins.epgsearch.numorbpos.choices) - 1
+	if oldVal > maxEntries:
+		config.plugins.epgsearch.numorbpos.value = str(maxEntries)
+	config.plugins.epgsearch.numorbpos.setChoices(choices, default="1")
+	updateUnusedOrbposConfig(choiceList, save)
+
+initOrbposConfigs()
+updateOrbposConfig(save=True)
+purgeOrbposConfig()
+
+config.plugins.epgsearch.enableorbpos = ConfigYesNo(default=False)
+config.plugins.epgsearch.invertorbpos = ConfigSelection(choices=[_("include"), _("exclude")], default=_("include"))

--- a/epgsearch/src/__init__.py
+++ b/epgsearch/src/__init__.py
@@ -7,7 +7,7 @@ from enigma import eServiceReference, eServiceCenter
 import os, gettext
 
 # Config
-from Components.config import config, configfile, ConfigSet, ConfigSubsection, ConfigSelection, ConfigNumber, ConfigYesNo, ConfigSatlist
+from Components.config import config, configfile, ConfigSet, ConfigSubsection, ConfigSelection, ConfigSelectionNumber, ConfigYesNo, ConfigSatlist
 
 PluginLanguageDomain = "EPGSearch"
 PluginLanguagePath = "Extensions/EPGSearch/locale"
@@ -36,7 +36,7 @@ config.plugins.epgsearch.showorbital = ConfigYesNo(default = allowShowOrbital)
 config.plugins.epgsearch.history = ConfigSet(choices = [])
 # XXX: configtext is more flexible but we cannot use this for a (not yet created) gui config
 config.plugins.epgsearch.encoding = ConfigSelection(choices = ['UTF-8', 'ISO8859-15'], default = 'UTF-8')
-config.plugins.epgsearch.history_length = ConfigNumber(default = 10)
+config.plugins.epgsearch.history_length = ConfigSelectionNumber(0, 50, 1, default = 10)
 config.plugins.epgsearch.add_search_to_epg = ConfigYesNo(default = True)
 
 orbposDisabled = 3600


### PR DESCRIPTION
Allow searches to be filtered by including or excluding sources by orbital position for satellites, or on whether the broadcasts are DVB-T or DVB-T.

Also use RIGHT/LEFT to change "Length of history" instead of using the numeric keys and tidy up when the history list is trimmed.
