### PR TITLE
Fix VKeyIcon

### DIFF
--- a/advancedmovieselection/src/AdvancedMovieSelectionSetup.py
+++ b/advancedmovieselection/src/AdvancedMovieSelectionSetup.py
@@ -36,6 +36,7 @@ from Screens.LocationBox import MovieLocationBox
 from Components.UsageConfig import preferredPath
 from Screens.MessageBox import MessageBox
 from MessageBoxEx import MessageBox as MessageBoxEx
+from Components.Sources.Boolean import Boolean
 from Components.Sources.List import List
 from Components.ActionMap import ActionMap, NumberActionMap
 from enigma import getDesktop, quitMainloop
@@ -1045,9 +1046,8 @@ class AdvancedMovieSelectionOwnButtonName(Screen, ConfigListScreen):
         self["menu"] = List(self.list)
         self["help"] = StaticText()
         self["key_red"] = StaticText(_("Save/Close"))
-        self["VKeyIcon"] = Pixmap()
+        self["VKeyIcon"] = Boolean(False)
         self["HelpWindow"] = Pixmap()
-        self["VKeyIcon"].hide()
         self["VirtualKB"].setEnabled(False)
         self.onShown.append(self.setWindowTitle)
         self.createSetup()
@@ -1180,11 +1180,11 @@ class AdvancedMovieSelectionOwnButtonName(Screen, ConfigListScreen):
             self.showKeypad()
 
     def enableVKeyIcon(self):
-        self["VKeyIcon"].show()
+        self["VKeyIcon"].boolean = True
         self["VirtualKB"].setEnabled(True)
 
     def disableVKeyIcon(self):
-        self["VKeyIcon"].hide()
+        self["VKeyIcon"].boolean = False
         self["VirtualKB"].setEnabled(False)
 
     def showKeypad(self, retval=None):

--- a/mytube/src/plugin.py
+++ b/mytube/src/plugin.py
@@ -10,6 +10,7 @@ from Components.Pixmap import Pixmap
 from Components.ProgressBar import ProgressBar
 from Components.ScrollLabel import ScrollLabel
 from Components.ServiceEventTracker import ServiceEventTracker
+from Components.Sources.Boolean import Boolean
 from Components.Sources.List import List
 from Components.Task import Task, Job, job_manager
 from Components.config import config, ConfigSelection, ConfigSubsection, ConfigText, ConfigYesNo, getConfigListEntry, ConfigPassword
@@ -239,7 +240,9 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 			<widget name="key_green" position="330,500" zPosition="5" size="140,40" valign="center" halign="center" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
 			<widget name="key_yellow" position="470,500" zPosition="5" size="140,40" valign="center" halign="center" font="Regular;21" transparent="1" foregroundColor="white" shadowColor="black" shadowOffset="-1,-1" />
 			<widget name="ButtonBlue" pixmap="skin_default/buttons/button_blue.png" position="610,510" zPosition="10" size="15,16" transparent="1" alphatest="on" />
-			<widget name="VKeyIcon" pixmap="skin_default/vkey_icon.png" position="620,495" zPosition="10" size="60,48" transparent="1" alphatest="on" />
+			<widget source="VKeyIcon" render="Pixmap" pixmap="skin_default/vkey_icon.png" position="620,495" zPosition="10" size="60,48" transparent="1" alphatest="on">
+				<convert type="ConditionalShowHide" />
+			</widget>
 			<widget name="thumbnail" position="0,0" size="100,75" alphatest="on"/> # fake entry for dynamic thumbnail resizing, currently there is no other way doing this.
 			<widget name="HelpWindow" position="160,255" zPosition="1" size="1,1" transparent="1" alphatest="on" />
 		</screen>"""
@@ -290,9 +293,8 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 		self["key_green"] = Button(_("Std. Feeds"))
 		self["key_yellow"] = Button(_("History"))
 		self["ButtonBlue"] = Pixmap()
-		self["VKeyIcon"] = Pixmap()
+		self["VKeyIcon"] = Boolean(False)
 		self["ButtonBlue"].hide()
-		self["VKeyIcon"].hide()
 		self["result"] = Label("")
 
 
@@ -478,7 +480,7 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 			self["historyactions"].setEnabled(False)
 			self["statusactions"].setEnabled(True)
 			self["ButtonBlue"].hide()
-			self["VKeyIcon"].hide()
+			self["VKeyIcon"].boolean = False
 			self.statuslist = []
 			self.hideSuggestions()
 			result = None
@@ -882,7 +884,7 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 		print "switchToSuggestionsList"
 		self.currList = "suggestionslist"
 		self["ButtonBlue"].hide()
-		self["VKeyIcon"].hide()
+		self["VKeyIcon"].boolean = False
 		self["statusactions"].setEnabled(False)
 		self["config_actions"].setEnabled(False)
 		self["videoactions"].setEnabled(False)
@@ -907,7 +909,7 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 		self["searchactions"].setEnabled(True)
 		self["key_green"].hide()
 		self["ButtonBlue"].show()
-		self["VKeyIcon"].show()
+		self["VKeyIcon"].boolean = True
 		self["config"].invalidateCurrent()
 		helpwindowpos = self["HelpWindow"].getPosition()
 		current = self["config"].getCurrent()
@@ -935,7 +937,7 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 		if len(self.videolist):
 			self.currList = "feedlist"
 			self["ButtonBlue"].hide()
-			self["VKeyIcon"].hide()
+			self["VKeyIcon"].boolean = False
 			self["videoactions"].setEnabled(True)
 			self["suggestionactions"].setEnabled(False)
 			self["searchactions"].setEnabled(False)
@@ -958,7 +960,7 @@ class MyTubePlayerMainScreen(Screen, ConfigListScreen):
 		print "switchToHistory oldlist",self.oldlist
 		self.hideSuggestions()
 		self["ButtonBlue"].hide()
-		self["VKeyIcon"].hide()
+		self["VKeyIcon"].boolean = False
 		self["key_green"].hide()
 		self["videoactions"].setEnabled(False)
 		self["suggestionactions"].setEnabled(False)

--- a/networkbrowser/src/MountEdit.py
+++ b/networkbrowser/src/MountEdit.py
@@ -5,6 +5,7 @@ from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Components.ActionMap import ActionMap
+from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
 from Components.config import config, ConfigIP, NoSave, ConfigText, ConfigEnableDisable, ConfigPassword, ConfigSelection, getConfigListEntry, ConfigYesNo
 from Components.ConfigList import ConfigListScreen
@@ -24,7 +25,9 @@ class AutoMountEdit(Screen, ConfigListScreen):
 			<widget name="config" position="5,50" size="550,250" zPosition="1" scrollbarMode="showOnDemand" />
 			<ePixmap pixmap="skin_default/div-h.png" position="0,420" zPosition="1" size="560,2" />
 			<widget source="introduction" render="Label" position="10,430" size="540,21" zPosition="10" font="Regular;21" halign="center" valign="center" backgroundColor="#25062748" transparent="1"/>
-			<widget name="VKeyIcon" pixmap="skin_default/buttons/key_text.png" position="10,430" zPosition="10" size="35,25" transparent="1" alphatest="on" />
+			<widget source="VKeyIcon" render="Pixmap" pixmap="skin_default/buttons/key_text.png" position="10,430" zPosition="10" size="35,25" transparent="1" alphatest="on">
+				<convert type="ConditionalShowHide" />
+			</widget>
 			<widget name="HelpWindow" pixmap="skin_default/vkey_icon.png" position="160,350" zPosition="1" size="1,1" transparent="1" alphatest="on" />
 		</screen>"""
 
@@ -64,7 +67,7 @@ class AutoMountEdit(Screen, ConfigListScreen):
 		self.createSetup()
 		self.onLayoutFinish.append(self.layoutFinished)
 		# Initialize Buttons
-		self["VKeyIcon"] = Pixmap()
+		self["VKeyIcon"] = Boolean(False)
 		self["HelpWindow"] = Pixmap()
 		self["introduction"] = StaticText(_("Press OK to activate the settings."))
 		self["key_red"] = StaticText(_("Cancel"))
@@ -89,7 +92,7 @@ class AutoMountEdit(Screen, ConfigListScreen):
 	def layoutFinished(self):
 		self.setup_title = _("Mounts editor")
 		Screen.setTitle(self, _(self.setup_title))
-		self["VKeyIcon"].hide()
+		self["VKeyIcon"].boolean = False
 		self["VirtualKB"].setEnabled(False)
 		self["HelpWindow"].hide()
 
@@ -303,13 +306,13 @@ class AutoMountEdit(Screen, ConfigListScreen):
 	def selectionChanged(self):
 		current = self["config"].getCurrent()
 		if current == self.mountusingEntry or current == self.activeEntry or current == self.ipEntry or current == self.mounttypeEntry or current == self.hdd_replacementEntry:
-			self["VKeyIcon"].hide()
+			self["VKeyIcon"].boolean = False
 			self["VirtualKB"].setEnabled(False)
 		else:
 			helpwindowpos = self["HelpWindow"].getPosition()
 			if current[1].help_window.instance is not None:
 				current[1].help_window.instance.move(ePoint(helpwindowpos[0],helpwindowpos[1]))
-				self["VKeyIcon"].show()
+				self["VKeyIcon"].boolean = True
 				self["VirtualKB"].setEnabled(True)
 
 	def ok(self):

--- a/networkbrowser/src/UserDialog.py
+++ b/networkbrowser/src/UserDialog.py
@@ -7,6 +7,7 @@ from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Components.ActionMap import ActionMap
 from Components.config import ConfigText, ConfigPassword, NoSave, getConfigListEntry
 from Components.ConfigList import ConfigListScreen
+from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
 from Components.Pixmap import Pixmap
 from Components.ActionMap import ActionMap, NumberActionMap
@@ -54,7 +55,9 @@ class UserDialog(Screen, ConfigListScreen):
 			<widget name="config" position="5,50" size="550,200" zPosition="1" scrollbarMode="showOnDemand" />
 			<ePixmap pixmap="skin_default/div-h.png" position="0,270" zPosition="1" size="560,2" />
 			<widget source="introduction" render="Label" position="10,280" size="540,21" zPosition="10" font="Regular;21" halign="center" valign="center" backgroundColor="#25062748" transparent="1"/>
-			<widget name="VKeyIcon" pixmap="skin_default/buttons/key_text.png" position="10,280" zPosition="10" size="35,25" transparent="1" alphatest="on" />
+			<widget source="VKeyIcon" render="Pixmap" pixmap="skin_default/buttons/key_text.png" position="10,280" zPosition="10" size="35,25" transparent="1" alphatest="on">
+				<convert type="ConditionalShowHide" />
+			</widget>
 			<widget name="HelpWindow" pixmap="skin_default/vkey_icon.png" position="410,330" zPosition="1" size="1,1" transparent="1" alphatest="on" />	
 		</screen>"""
 
@@ -85,7 +88,7 @@ class UserDialog(Screen, ConfigListScreen):
 		self.createSetup()
 		self.onLayoutFinish.append(self.layoutFinished)
 		# Initialize Buttons
-		self["VKeyIcon"] = Pixmap()
+		self["VKeyIcon"] = Boolean(False)
 		self["HelpWindow"] = Pixmap()
 		self["introduction"] = StaticText(_("Press OK to save settings."))
 		self["key_red"] = StaticText(_("Close"))

--- a/networkbrowserpli/src/MountEdit.py
+++ b/networkbrowserpli/src/MountEdit.py
@@ -5,6 +5,7 @@ from Screens.Screen import Screen
 from Screens.MessageBox import MessageBox
 from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Components.ActionMap import ActionMap
+from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
 from Components.config import config, ConfigIP, NoSave, ConfigText, ConfigEnableDisable, ConfigPassword, ConfigSelection, getConfigListEntry, ConfigYesNo
 from Components.ConfigList import ConfigListScreen
@@ -22,7 +23,9 @@ class AutoMountEdit(Screen, ConfigListScreen):
 			<widget name="config" position="5,50" size="550,250" zPosition="1" scrollbarMode="showOnDemand" />
 			<ePixmap pixmap="skin_default/div-h.png" position="0,420" zPosition="1" size="560,2" />
 			<widget source="introduction" render="Label" position="10,430" size="540,21" zPosition="10" font="Regular;21" halign="center" valign="center" backgroundColor="#25062748" transparent="1"/>
-			<widget name="VKeyIcon" pixmap="skin_default/buttons/key_text.png" position="10,430" zPosition="10" size="35,25" transparent="1" alphatest="on" />
+			<widget source="VKeyIcon" render="Pixmap" pixmap="skin_default/buttons/key_text.png" position="10,430" zPosition="10" size="35,25" transparent="1" alphatest="on">
+				<convert type="ConditionalShowHide" />
+			</widget>
 			<widget name="HelpWindow" pixmap="skin_default/vkey_icon.png" position="160,350" zPosition="1" size="1,1" transparent="1" alphatest="on" />	
 		</screen>"""
 
@@ -59,7 +62,7 @@ class AutoMountEdit(Screen, ConfigListScreen):
 		self.createSetup()
 		self.onLayoutFinish.append(self.layoutFinished)
 		# Initialize Buttons
-		self["VKeyIcon"] = Pixmap()
+		self["VKeyIcon"] = Boolean(False)
 		self["HelpWindow"] = Pixmap()
 		self["introduction"] = StaticText(_("Press OK to activate the settings."))
 		self["key_red"] = StaticText(_("Cancel"))
@@ -67,7 +70,7 @@ class AutoMountEdit(Screen, ConfigListScreen):
 
 	def layoutFinished(self):
 		self.setTitle(_("Mounts editor"))
-		self["VKeyIcon"].hide()
+		self["VKeyIcon"].boolean = False
 		self["VirtualKB"].setEnabled(False)
 		self["HelpWindow"].hide()
 
@@ -246,13 +249,13 @@ class AutoMountEdit(Screen, ConfigListScreen):
 	def selectionChanged(self):
 		current = self["config"].getCurrent()
 		if current == self.activeEntry or current == self.ipEntry or current == self.mounttypeEntry or current == self.hdd_replacementEntry:
-			self["VKeyIcon"].hide()
+			self["VKeyIcon"].boolean = False
 			self["VirtualKB"].setEnabled(False)
 		else:
 			helpwindowpos = self["HelpWindow"].getPosition()
 			if current[1].help_window.instance is not None:
 				current[1].help_window.instance.move(ePoint(helpwindowpos[0],helpwindowpos[1]))
-				self["VKeyIcon"].show()
+				self["VKeyIcon"].boolean = True
 				self["VirtualKB"].setEnabled(True)
 
 	def ok(self):

--- a/networkbrowserpli/src/UserDialog.py
+++ b/networkbrowserpli/src/UserDialog.py
@@ -7,6 +7,7 @@ from Screens.VirtualKeyBoard import VirtualKeyBoard
 from Components.ActionMap import ActionMap
 from Components.config import ConfigText, ConfigPassword, NoSave, getConfigListEntry
 from Components.ConfigList import ConfigListScreen
+from Components.Sources.Boolean import Boolean
 from Components.Sources.StaticText import StaticText
 from Components.Pixmap import Pixmap
 from Components.ActionMap import ActionMap, NumberActionMap
@@ -54,7 +55,9 @@ class UserDialog(Screen, ConfigListScreen):
 			<widget name="config" position="5,50" size="550,200" zPosition="1" scrollbarMode="showOnDemand" />
 			<ePixmap pixmap="skin_default/div-h.png" position="0,270" zPosition="1" size="560,2" />
 			<widget source="introduction" render="Label" position="10,280" size="540,21" zPosition="10" font="Regular;21" halign="center" valign="center" backgroundColor="#25062748" transparent="1"/>
-			<widget name="VKeyIcon" pixmap="skin_default/buttons/key_text.png" position="10,280" zPosition="10" size="35,25" transparent="1" alphatest="on" />
+			<widget source="VKeyIcon" render="Pixmap" pixmap="skin_default/buttons/key_text.png" position="10,280" zPosition="10" size="35,25" transparent="1" alphatest="on">
+				<convert type="ConditionalShowHide" />
+			</widget>
 			<widget name="HelpWindow" pixmap="skin_default/vkey_icon.png" position="160,250" zPosition="1" size="1,1" transparent="1" alphatest="on" />	
 		</screen>"""
 
@@ -85,7 +88,7 @@ class UserDialog(Screen, ConfigListScreen):
 		self.createSetup()
 		self.onLayoutFinish.append(self.layoutFinished)
 		# Initialize Buttons
-		self["VKeyIcon"] = Pixmap()
+		self["VKeyIcon"] = Boolean(False)
 		self["HelpWindow"] = Pixmap()
 		self["introduction"] = StaticText(_("Press OK to save settings."))
 		self["key_red"] = StaticText(_("Close"))


### PR DESCRIPTION
This change makes the VKeyIcon a Boolean and fixes the cross definitions between a Boolean and a Pixmap across the code base.

- [AdvancedMovieSelectionSetup] Make VKeyIcon a Boolean 
- [plugin] Make VKeyIcon a Boolean
- [MountEdit] Make VKeyIcon a Boolean
- [UserDialog] Make VKeyIcon a Boolean
- [MountEdit] Make VKeyIcon a Boolean
- [UserDialog] Make VKeyIcon a Boolean

This pull request may have implications for skins that don't use the standard VKeyIcon bpplean coding.
