### PR TITLE
Fix crash when Audio Sync settings are selected on a HDMI IN service

### DIFF
--- a/audiosync/src/AC3delay.py
+++ b/audiosync/src/AC3delay.py
@@ -165,8 +165,10 @@ class AC3delay:
         oAudioTracks = self.iService and self.iService.audioTracks()
         n = oAudioTracks and oAudioTracks.getNumberOfTracks() or 0
         tlist = []
-        self.selectedAudioIndex = oAudioTracks.getCurrentTrack()
-        if n >= 0:
+        self.selectedAudioInfo = ("", 0)
+        self.selectedAudioIndex = None
+        if n > 0:
+            self.selectedAudioIndex = oAudioTracks.getCurrentTrack()
             for x in range(n):
                 i = oAudioTracks.getTrackInfo(x)
                 language = i.getLanguage()
@@ -189,7 +191,7 @@ class AC3delay:
                     self.selectedAudioInfo = (description, x)
             tlist.sort(key=lambda x: x[0])
 
-            self.audioTrackList = tlist
+        self.audioTrackList = tlist
         for sAudio in AC3PCM:
             self.systemDelay[sAudio]=self.getSystemDelay(sAudio)
         del oAudioTracks


### PR DESCRIPTION
Problem found on Beyonwiz T4 with HDMI IN.

When HDMI IN is the service being viewed live, enter
the "Select audio track" popup (long-AUDIO
on Beyonwiz image, may be short-AUDIO in other images).

Press BLUE Audio Sync, crash.

The problem is due to `eServiceHDMI::audioTracks()`
returning `None` in Python. This condition is not correctly tested for
in `AC3delay.getAudioInformation()` and the UI crashes
when `oAudioTracks.getCurrentTrack()` is called when
`oAudioTracks is None`.

The problem is also likely to occur when Xine services are
being played, since `eServiceXine::audioTracks()` also returns None.

The fix ensures that `oAudioTracks.getCurrentTrack()` is only
called when `oAudioTracks is not None`, and that other values
normally set in `AC3delay.getAudioInformation()` are given
sensible default values when `oAudioTracks is None` and
other `iPlayableService` audio-related methods
return `None` in Python.