### PR TITLE
Added 720p50 handlers and some 2160p changes

### DIFF
--- a/autoresolution/src/plugin.py
+++ b/autoresolution/src/plugin.py
@@ -38,12 +38,33 @@ port = None
 videoresolution_dictionary = {}
 resolutionlabel = None
 
-resolutions = (('sd_i_50', (_("SD 25/50HZ Interlace Mode"))), ('sd_i_60', (_("SD 30/60HZ Interlace Mode"))), \
-			('sd_p_24', (_("SD 24HZ Progressive mode"))), \
-			('sd_p_50', (_("SD 25/50HZ Progressive Mode"))), ('sd_p_60', (_("SD 30/60HZ Progressive Mode"))), \
-			('hd_i', (_("HD Interlace Mode"))), ('hd_p', (_("HD Progressive Mode"))), \
-			('p720_24', (_("Enable 720p24 Mode"))), ('p1080_24', (_("Enable 1080p24 Mode"))), \
-			('p1080_25', (_("Enable 1080p25 Mode"))), ('p1080_30', (_("Enable 1080p30 Mode"))))
+# Added p720_50
+resolutions = ( \
+	('sd_i_50',        _("SD 25/50HZ Interlace Mode")), \
+	('sd_i_60',        _("SD 30/60HZ Interlace Mode")), \
+	('sd_p_24',        _("SD 24HZ Progressive mode")), \
+	('sd_p_50',        _("SD 25/50HZ Progressive Mode")), \
+	('sd_p_60',        _("SD 30/60HZ Progressive Mode")), \
+	('hd_i',           _("HD Interlace Mode")), \
+	('hd_p',           _("HD Progressive Mode")), \
+	('p720_24',        _("Enable 720p24 Mode")), \
+	('p720_50',        _("Enable 720p50 Mode")), \
+	('p1080_24',       _("Enable 1080p24 Mode")), \
+	('p1080_25',       _("Enable 1080p25 Mode")), \
+	('p1080_30',       _("Enable 1080p30 Mode")), \
+)
+
+# from OpenPLi
+have_2160p = config.av.videorate.get("2160p", False)
+
+if have_2160p:				        
+	resolutions += (
+		('uhd_i',    _("UHD Interlace Mode")),
+		('uhd_p',    _("UHD Progressive Mode")),
+		('p2160_24', _("Enable 2160p24 Mode")),
+		('p2160_25', _("Enable 2160p25 Mode")),
+		('p2160_30', _("Enable 2160p30 Mode")), # Trailing , is NEEDED!
+)
 
 config.plugins.autoresolution = ConfigSubsection()
 config.plugins.autoresolution.enable = ConfigYesNo(default = False)
@@ -175,7 +196,31 @@ class AutoRes(Screen):
 			if self.extra_mode1080p60:
 				default_choices.append('1080p60')
 			for mode in resolutions:
-				choices = default_choices + preferedmodes
+# from OpenPLi
+				if have_2160p:
+					if mode[0].startswith('p2160'):
+						choices = ['2160p24', '2160p25', '2160p30'] + preferedmodes
+					elif mode[0].startswith('p1080_24'):
+						choices = ['1080p24', '2160p24'] + preferedmodes
+					elif mode[0].startswith('p1080'):
+						choices = ['1080p24', '1080p25', '1080p30'] + preferedmodes
+					elif mode[0] == 'p720_24':
+						choices = ['720p24', '1080p24', '2160p24'] + preferedmodes
+# Added p720_50
+					elif mode[0] == 'p720_50':
+						choices = ['720p50', '1080p25', '2160p25'] + preferedmodes
+					else:
+						choices = default_choices + preferedmodes
+				else:
+					if mode[0].startswith('p1080'):
+						choices = ['1080p24', '1080p25', '1080p30'] + preferedmodes
+					elif mode[0] == 'p720_24':
+						choices = ['720p24', '1080p24'] + preferedmodes
+# Added p720_50
+					elif mode[0] == 'p720_50':
+						choices = ['720p50', '1080p25'] + preferedmodes
+					else:
+						choices = default_choices + preferedmodes
 				config.plugins.autoresolution.videoresolution[mode[0]] = ConfigSelection(default = default[0], choices = choices)
 				config.plugins.autoresolution.videoresolution[mode[0]].addNotifier(self.modeConfigChanged, initial_call = False, immediate_feedback = False)
 				videoresolution_dictionary[mode[0]] = (config.plugins.autoresolution.videoresolution[mode[0]])
@@ -227,13 +272,23 @@ class AutoRes(Screen):
 				progressive = info and info.getInfo(iServiceInformation.sProgressive)
 
 				prog = progressive == 1 and 'p' or 'i'
-
-				if frate in ('24'): # always 1080p24 content ???
+# from OpenPLi
+				if have_2160p and (height >= 2100 or width >= 3200): # 2160 content
+					if frate in ('24', '25', '30') and prog == 'p':
+						new_mode = 'p2160_%s' % frate
+					elif frate in ('50', '60') and prog == 'p':
+						new_mode = 'uhd_p'
+					else:
+						new_mode = 'uhd_i' # 2160i content - senseless ???
+				elif frate in ('24'): # always 1080p24 content ???
 					new_mode = 'p1080_24'
 				elif (height >= 900 or width >= 1600) and frate in ('24', '25', '30') and prog == 'p': # 1080p content
 					new_mode = 'p1080_%s' % frate
 				elif (height > 576 or width > 720) and frate == '24' and prog == 'p': # 720p24 detection
 					new_mode = 'p720_24'
+# Added p720_50
+				elif (height > 576 or width > 720) and frate == '50' and prog == 'p': # 720p50 detection
+					new_mode = 'p720_50'
 				elif (height <= 576) and (width <= 720) and frate in ('25', '50'):
 					new_mode = 'sd_%s_50' % prog
 				elif (height <= 480) and (width <= 720) and frate in ('24', '30', '60'):


### PR DESCRIPTION
The additional 1080p* options [default_choices] have been re-instated (they were unintentionally omitted from the previous change).
Now fixed up for 720p50 to show for 720p50 signal.