### PR TITLE
Update shoutcast.pot

### DIFF
--- a/shoutcast/po/shoutcast.pot
+++ b/shoutcast/po/shoutcast.pot
@@ -188,11 +188,6 @@ msgstr ""
 msgid "search-criteria %s"
 msgstr ""
 
-#: ../src/plugin.py:614
-#, python-format
-msgid "SHOUTcast station list for %s"
-msgstr ""
-
 #: ../src/plugin.py:616
 #, python-format
 msgid "Searching SHOUTcast for %s..."


### PR DESCRIPTION
File unusable - duplicating entry "SHOUTcast station list for %s" in *.pot file. Deleted