### PR TITLE
[AutoTimer] fix checking for duplicates with extended description

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -814,7 +814,7 @@ class AutoTimer:
 					# If the similarity percent is higher then 0.7 it is a very close match
 					foundShort = ( 0.7 < SequenceMatcher(lambda x: x == " ",shortdesc1, shortdesc2).ratio() )
 					if foundShort:
-						if timer.searchForDuplicateDescription == 3:
+						if timer.searchForDuplicateDescription == 2:
 							if extdesc1 and extdesc2:
 								# Some channels indicate replays in the extended descriptions
 								# If the similarity percent is higher then 0.7 it is a very close match


### PR DESCRIPTION
searchForDuplicateDescription only has values from 0 to 2:
0: title only
1: title and short description
2: title, short description and extended description

so checking for value 3 will ignore the extended description, and
together with the questionable fuzzy matching used in the
checkSimilarity function will cause

   Title: Some Serialized Show
   Short: A Cliffhanger Episode (part 1)
   Desc:  Oh, this one is getting interesting...

and

   Title: Some Serialized Show
   Short: A Cliffhanger Episode (part 2)
   Desc:  Hope you didn't miss this one, since there will be no rerun

to be considered the same,  and only part 1 will get a timer.
The fuzzy-matching will treat the short description as being the same,
and since the description is ignored you get enraged since you'll never
know how that cliffhanger was resolved…

this patch fixes the check, so extended descirption is used in the
comparison.

I think the fuzzymatch in comparison of the short-description is harmful/makes using the "title & short description" option useless, too often there are "part x" episodes that you'll miss when using that.
I rather have a "rerun" one recorded in addition, than missing a part of a split movie/multipart episode.