### PR TITLE
Fix AutoTimer "description" search failure if no service restrictions

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -369,9 +369,9 @@ class AutoTimer:
 								service = services.getNext()
 								if not service.valid():
 									break
-									playable = not (service.flags & (eServiceReference.isMarker|eServiceReference.isDirectory)) or (service.flags & eServiceReference.isNumberedMarker)
-									if playable:
-										test.append((service.toString(), 0, -1, -1))
+								playable = not (service.flags & (eServiceReference.isMarker|eServiceReference.isDirectory)) or (service.flags & eServiceReference.isNumberedMarker)
+								if playable:
+									test.append((service.toString(), 0, -1, -1))
 
 			if test:
 				# Get all events


### PR DESCRIPTION
If an `AutoTimer` with "description" Search type is created with no
service or bouquet restrictions, the timer won't match events that
contain the description text.

_Replication steps_

In any convenient way, create an AutoTimer with "description" Search
type and a "Match title" string that is known to match at least one
instance of a program. Set its Restrict to specific bouquets setting
to a bouquet that contains the program (e.g. Terrestrial TV LCN).

Verify that the AutoTimer matches programs as expected using
MENU>Preview in the AutoTimer list screen.

Remove the restriction in Restrict to specific bouquets.

MENU>Preview now matches no programs.

_Fix_

Remove excess indentation in part of `AutoTimer.parseTimer()` loop
over all services in all bouquets.