### PR TITLE
[EPGSearch.py] Use the system VirtualKeyBoard

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -17,7 +17,7 @@ from Screens.EpgSelection import EPGSelection
 from Screens.MessageBox import MessageBox
 from Screens.HelpMenu import HelpableScreen
 from Screens.Screen import Screen
-from Plugins.SystemPlugins.Toolkit.NTIVirtualKeyBoard import NTIVirtualKeyBoard
+from Screens.VirtualKeyBoard import VirtualKeyBoard
 
 from Components.ActionMap import ActionMap, HelpableActionMap
 from Components.Button import Button
@@ -432,7 +432,7 @@ class EPGSearch(EPGSelection):
 		self.close()
 
 	def yellowButtonPressed(self):
-		self.session.openWithCallback(self.searchEPG, NTIVirtualKeyBoard, title=_("Enter text to search for"))
+		self.session.openWithCallback(self.searchEPG, VirtualKeyBoard, title=_("Enter text to search for"))
 
 	def menu(self):
 		options = [


### PR DESCRIPTION
This code used to call a reclass of the VirtualKeyBoard called NTIVirtualKeyBoard that lives in the System Toolkit plugin.

The NTIVirtualKeyBoard appears to have been used to implement SMS data entry into an older version of the VirtualKeyBoard.  That functionality is now native in the current VirtualKeyBoard.

This change addresses a data entry issue in the EPGSearch functionality where the cursor position is not correctly updated during SMS style data entry.
