### PR TITLE
[EPGSearch.py] Initialise NewSearch string

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -432,7 +432,7 @@ class EPGSearch(EPGSelection):
 		self.close()
 
 	def yellowButtonPressed(self):
-		self.session.openWithCallback(self.searchEPG, VirtualKeyBoard, title=_("Enter text to search for"))
+		self.session.openWithCallback(self.searchEPG, VirtualKeyBoard, title=_("Enter text to search for"), text=self.currSearch)
 
 	def menu(self):
 		options = [


### PR DESCRIPTION
Prime the NewSearch search string with previous search string.  This allows users to make multiple related searches without all the text entry time.

If a totally new search is required then simply select the CLR button first.

Thank you Rob for the suggestion.
