### PR TITLE
Tweak user ratings pattern match

### DIFF
--- a/imdb/src/plugin.py
+++ b/imdb/src/plugin.py
@@ -303,7 +303,7 @@ class IMDB(Screen, HelpableScreen):
 			, re.DOTALL)
 
 			self.genreblockmask = re.compile('<h4 class="inline">Genres?:</h4>\s*?(.*?)\s+?(?:Mehr|See more|</p|<a class|</div>)', re.DOTALL)
-			self.ratingmask = re.compile('<div class="ratingValue">.*?<span>(?P<rating>.*?)</span>', re.DOTALL)
+			self.ratingmask = re.compile('<div class="ratingValue">.*?<span itemprop="ratingValue">(?P<rating>.*?)</span>', re.DOTALL)
 			self.castmask = re.compile('<td>\s*<a href=.*?>(?P<actor>.*?)\s*</a>\s*</td>.*?<td class="character">(?P<character>.*?)(?:<a href="#"\s+class="toggle-episodes".*?>(?P<episodes>.*?)</a>.*?)?</td>', re.DOTALL)
 			#self.postermask = re.compile('<td .*?id="img_primary">.*?<img .*?src=\"(http.*?)\"', re.DOTALL)
 			self.postermask = re.compile('<div class="poster">.*?<img .*?src=\"(http.*?)\"', re.DOTALL)


### PR DESCRIPTION
The HTML for the IMDb user ratings display has changed.

The change causes most series Details displays (e.g. for Castle)
to fail with a ValueError: could not convert string to float
exception.

Some (especially older) movies fail in the same way (e.g. Pocketful
of Miracles)).  Newer movies often don't crash, but display the
MetaCritic rating instead of the IMDb user rating. This often shows
impossibly high ratings (e.g. 72/10 for Full Metal Jacket).

Tweak the user ratings regular expression match to correctly extract
the user rating.