### PR TITLE
Fix crash when EPGSelection has list in skinNames

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -201,7 +201,9 @@ class EPGSearch(EPGSelection):
 
 	def __init__(self, session, *args, **kwargs):
 		Screen.__init__(self, session)
-		self.skinName = [self.skinName, "EPGSelection"]
+		if not isinstance(self.skinName, list):
+			self.skinName = [self.skinName]
+		self.skinName.append("EPGSelection")
 		if isinstance(self, HelpableScreen):
 			HelpableScreen.__init__(self)
 
@@ -876,7 +878,9 @@ class EPGSearchChannelSelection(SimpleChannelSelection):
 class EPGSearchEPGSelection(EPGSelection):
 	def __init__(self, session, ref, openPlugin, eventid=None):
 		EPGSelection.__init__(self, session, ref.toString(), eventid=eventid)
-		self.skinName = [self.skinName, "EPGSelection"]
+		if not isinstance(self.skinName, list):
+			self.skinName = [self.skinName]
+		self.skinName.append("EPGSelection")
 		self["key_green"].text = _("Search")
 		self.openPlugin = openPlugin
 


### PR DESCRIPTION
This PR fixes a crash that occurs when using EPGSearch's _import from EPG_ screens, when `EPGSelection` has been extended to have a list of skin names in `self.skinNames`. This isn't an issue with the current EPGSelection, but there is work in OpenVix to rationalise the EPGs, which also simplify the skin names and require a list to be used for backwards compatibility.