### PR TITLE
[imdb] Fix font escape sequences

### DIFF
--- a/imdb/src/plugin.py
+++ b/imdb/src/plugin.py
@@ -309,6 +309,8 @@ class IMDB(Screen, HelpableScreen):
 			self.postermask = re.compile('<div class="poster">.*?<img .*?src=\"(http.*?)\"', re.DOTALL)
 
 		self.htmltags = re.compile('<.*?>', re.DOTALL)
+		self.fontescapes = re.compile('\\\\([cnrt])')
+		self.fontescsub = '\\\\\\r\\1'
 
 	def resetLabels(self):
 		self["detailslabel"].setText("")
@@ -747,6 +749,8 @@ class IMDB(Screen, HelpableScreen):
 			Titeltext = self.generalinfos.group("title").replace(self.NBSP, ' ').strip()
 			if len(Titeltext) > 57:
 				Titeltext = Titeltext[0:54] + "..."
+
+			Titeltext = self.fontescapes.sub(self.fontescsub, Titeltext)
 			self["title"].setText(Titeltext)
 
 			Detailstext = ""
@@ -796,6 +800,8 @@ class IMDB(Screen, HelpableScreen):
 					Casttext = _("Cast: ") + Casttext
 				else:
 					Casttext = _("No cast list found in the database.")
+
+				Casttext = self.fontescapes.sub(self.fontescsub, Casttext)
 				self["castlabel"].setText(Casttext)
 
 			posterurl = self.postermask.search(self.inhtml)
@@ -845,9 +851,12 @@ class IMDB(Screen, HelpableScreen):
 					Extratext += "\n" + extrainfos.group("g_comments") + ":\n" + extrainfos.group("commenttitle") + " [" + ' '.join(self.htmltags.sub('',extrainfos.group("commenter")).split()) + "]: " + self.htmltags.sub('',extrainfos.group("comment").replace("\n",' ').replace(self.NBSP, ' ').replace("<br>", '\n').replace("<br/>",'\n').replace("<br />",'\n')) + "\n"
 
 			if Extratext:
+				Extratext = self.fontescapes.sub(self.fontescsub, Extratext)
 				self["extralabel"].setText(Extratext)
 				self["extralabel"].hide()
 				self["key_blue"].setText(_("Extra Info"))
+
+		Detailstext = self.fontescapes.sub(self.fontescsub, Detailstext)
 
 		self["detailslabel"].setText(Detailstext)
 		self.callbackData = Detailstext


### PR DESCRIPTION
If the IMDb text contains any of the strings "\c", "\n", "\r" or
"\t", they are interpreted as escape sequences by
eTextPara::renderString().

Unfortunately, renderString() does not provide a clean way to escape
the "\" character, so the "\" that is to appear in the text is
separated from the alpha character by a <CR>, which is a no-op in
eTextPara::renderString().

So, for example, "\c" in the IMDb text is transformed into "\<CR>c",
which then displays as "\c" on the screen.

There really should be a clean way to escape the escape character
in renderString().

The change is prompted by real data in IMDB. In the Trivia section
the movie "The Core" (2003) a commenter uses "\" where "/" would
normally be used: "In the 1950s\60s, during the design\construction
of the SR-71 Blackbird ...". The "\c..." is rendered as a colour
change.