### PR TITLE
Enhancements to allow editing a timer's autotimer

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -112,7 +112,7 @@ class AutoTimer:
 		# Initialize
 		self.timers = []
 		self.configMtime = -1
-		self.uniqueTimerId = 0
+		self.nextTimerId = 1
 		self.defaultTimer = preferredAutoTimerComponent(
 			0,		# Id
 			"",		# Name
@@ -120,7 +120,7 @@ class AutoTimer:
 			True 	# Enabled
 		)
 
-# Configuration
+	# Configuration
 	def readXml(self, **kwargs):
 		if "xml_string" in kwargs:
 			# reset time
@@ -184,7 +184,9 @@ class AutoTimer:
 			0,
 			self.defaultTimer
 		)
-		self.uniqueTimerId = len(self.timers)
+		self.nextTimerId = int(configuration.get("nextTimerId", "0"))
+		if not self.nextTimerId:
+			self.nextTimerId = len(self.timers) + 1
 
 	def getXml(self, webif = True):
 		return buildConfig(self.defaultTimer, self.timers, webif)
@@ -200,20 +202,19 @@ class AutoTimer:
 	def readXmlTimer(self, xml_string):
 		# Parse xml string
 		configuration = cet_fromstring(xml_string)
-		
+
 		parseConfig(
 			configuration,
 			self.timers,
 			configuration.get("version"),
-			self.uniqueTimerId,
+			self.getUniqueId(),
 			self.defaultTimer
 		)
-		self.uniqueTimerId += 1
-		
+
 		# reset time
 		self.configMtime = -1
 
-# Manage List
+	# Manage List
 	def add(self, timer):
 		self.timers.append(timer)
 
@@ -233,8 +234,9 @@ class AutoTimer:
 		return [(x,) for x in lst]
 
 	def getUniqueId(self):
-		self.uniqueTimerId += 1
-		return self.uniqueTimerId
+		newId = self.nextTimerId
+		self.nextTimerId += 1
+		return newId
 
 	def remove(self, uniqueId):
 		idx = 0
@@ -595,7 +597,7 @@ class AutoTimer:
 						if timer.avoidDuplicateDescription >= 2:
 							if self.checkSimilarity(timer, name, rtimer.name, shortdesc, rtimer.description, extdesc, rtimer.extdesc ):
 								oldExists = True
-#								print("[AutoTimer] We found a timer (any service) with same description, skipping event")
+								# print("[AutoTimer] We found a timer (any service) with same description, skipping event")
 								break
 				if oldExists:
 					continue
@@ -609,9 +611,8 @@ class AutoTimer:
 				newEntry.log(509, "[AutoTimer] Timer start on: %s" % ctime(begin))
 				
 				# Mark this entry as AutoTimer (only AutoTimers will have this Attribute set)
-				# It is only temporarily, after a restart it will be lost,
-				# because it won't be stored in the timer xml file
 				newEntry.isAutoTimer = True
+				newEntry.autoTimerId = timer.id
 
 			# Apply afterEvent
 			if timer.hasAfterEvent():

--- a/autotimer/src/AutoTimerConfiguration.py
+++ b/autotimer/src/AutoTimerConfiguration.py
@@ -77,6 +77,11 @@ def parseEntry(element, baseTimer, defaults = False):
 			print('[AutoTimer] Erroneous config is missing attribute "match", skipping entry')
 			return False
 
+		# Read out id
+		id = int(element.get("id", "0"))
+		if id:
+			baseTimer.id = id
+
 		# Read out name
 		baseTimer.name = element.get("name", "").encode("UTF-8")
 		if not baseTimer.name:
@@ -526,7 +531,7 @@ def parseConfigOld(configuration, list, uniqueTimerId = 0):
 
 def buildConfig(defaultTimer, timers, webif = False):
 	# Generate List in RAM
-	list = ['<?xml version="1.0" ?>\n<autotimer version="', CURRENT_CONFIG_VERSION, '">\n\n']
+	list = ['<?xml version="1.0" ?>\n<autotimer version="', CURRENT_CONFIG_VERSION, '" nextTimerId="', "1", '">\n\n']
 	append = list.append
 	extend = list.extend
 	defaultEncoding = getDefaultEncoding()
@@ -671,7 +676,7 @@ def buildConfig(defaultTimer, timers, webif = False):
 			extend(('  <tag>', stringToXML(tag), '</tag>\n'))
 
 	# Keep the list clean
-	if len(list) == 5:
+	if len(list) == 7:
 		list.pop() # >
 		list.pop() # <defaults
 	else:
@@ -681,8 +686,7 @@ def buildConfig(defaultTimer, timers, webif = False):
 	for timer in timers:
 		# Common attributes (match, enabled)
 		extend((' <timer name="', stringToXML(timer.name), '" match="', stringToXML(timer.match), '" enabled="', timer.getEnabled(), '"'))
-		if webif:
-			extend((' id="', str(timer.getId()),'"'))
+		extend((' id="', str(timer.getId()),'"'))
 
 		# Timespan
 		if timer.hasTimespan():
@@ -833,6 +837,7 @@ def buildConfig(defaultTimer, timers, webif = False):
 	# End of Configuration
 	append('</autotimer>\n')
 
+	from plugin import autotimer
+	list[3] = str(autotimer.nextTimerId)
+
 	return list
-
-

--- a/autotimer/src/AutoTimerEditor.py
+++ b/autotimer/src/AutoTimerEditor.py
@@ -1539,6 +1539,42 @@ def addAutotimerFromEvent(session, evt = None, service = None):
 		[]			# Proposed tags
 	)
 
+def addAutotimerFromTimer(session, timer):
+	from AutoTimerComponent import preferredAutoTimerComponent
+	from AutoTimerImporter import AutoTimerImporter
+	from plugin import autotimer
+
+	autotimer.readXml()
+
+	match = timer.name
+	sref = timer.service_ref
+	# timespan defaults to +- 1h
+	begin = timer.begin + config.recording.margin_before.value * 60 - 3600
+	end = timer.end - config.recording.margin_after.value * 60 + 7200
+
+	# XXX: we might want to make sure that we actually collected any data because the importer does not do so :-)
+
+	newTimer = autotimer.defaultTimer.clone()
+	newTimer.id = autotimer.getUniqueId()
+	newTimer.name = match
+	newTimer.match = ''
+	newTimer.enabled = True
+
+	session.openWithCallback(
+		importerCallback,
+		AutoTimerImporter,
+		newTimer,
+		match,		# Proposed Match
+		begin,		# Proposed Begin
+		end,		# Proposed End
+		None,		# Proposed Disabled
+		sref,		# Proposed ServiceReference
+		None,		# Proposed afterEvent
+		None,		# Proposed justplay
+		None,		# Proposed dirname
+		[]			# Proposed tags
+	)
+
 def addAutotimerFromService(session, service = None):
 	from AutoTimerComponent import preferredAutoTimerComponent
 	from AutoTimerImporter import AutoTimerImporter
@@ -1597,6 +1633,16 @@ def addAutotimerFromService(session, service = None):
 		path,		# Proposed dirname
 		tags		# Proposed tags
 	)
+
+def editAutotimerFromTimer(session, timer):
+	from plugin import autotimer
+
+	autotimer.readXml()
+
+	for search in autotimer.getTimerList():
+		if search.id == timer.autoTimerId:
+			session.openWithCallback(editorCallback, AutoTimerEditor, search)
+			break
 
 def importerCallback(ret):
 	if ret:


### PR DESCRIPTION
1. Provide a method to edit the autotimer given a timer.
1. persisting the autotimer's `id` in autotimer.xml
1. storing `autoTimerId` on each timer that it creates
1. Also provide a method to create an autotimer from a timer

Note that 3 requires changes in enigma2's [RecordTimer.py](https://github.com/SimonCapewell/enigma2/commit/6ef4cb2cc4fc8abeda26f35aa649f6921454f7f5#diff-0f321e0c10bf545be5c64a41d09d6732) to save the new attribute to timer.xml

This is a companion piece to go with the work in https://github.com/SimonCapewell/enigma2/tree/epg-custom-buttons to enable enter editing an autotimer from the EPG screens in the same way you can edit a standard timer.