### PR TITLE
[EPGRefresh] Make ActionMaps compatible with new ConfigListScreen

### DIFF
--- a/epgrefresh/src/EPGRefreshChannelEditor.py
+++ b/epgrefresh/src/EPGRefreshChannelEditor.py
@@ -88,7 +88,7 @@ class EPGRefreshServiceEditor(Screen, ConfigListScreen):
 				"save": self.save,
 				"yellow": self.removeService,
 				"blue": self.newService
-			}
+			}, prio=-2
 		)
 
 		# Trigger change
@@ -184,6 +184,9 @@ class EPGRefreshServiceEditor(Screen, ConfigListScreen):
 
 	def cancel(self):
 		self.close(None)
+
+	def closeRecursive(self):
+		self.cancel()
 
 	def save(self):
 		self.saveCurrent()

--- a/epgrefresh/src/EPGRefreshConfiguration.py
+++ b/epgrefresh/src/EPGRefreshConfiguration.py
@@ -351,6 +351,9 @@ class EPGRefreshConfiguration(Screen, HelpableScreen, ConfigListScreen):
 		else:
 			self.close(self.session, False)
 	
+	def closeRecursive(self):
+		self.keyCancel()
+
 	def _saveConfiguration(self):
 		epgrefresh.services = (set(self.services[0]), set(self.services[1]))
 		epgrefresh.saveConfiguration()


### PR DESCRIPTION
Changes to ActionMaps in recent changes to ViX ConfigListScreen
caused problems in ViX 5.4.001.002.

An ActionMap in EPGRefreshServiceEditor updated to -2, so that its
actions override the corresponding actions in ConfigListScreen.
Otherwise the save and cancel actions in ConfigListScreen are used
insted of those in EPGRefreshServiceEditor.

Added closeRecursive() methods to EPGRefreshConfiguration and
EPGRefreshServiceEditor to override those methods on the cancel
action in versions of ConfigListScreen that have them.

Backwards compatibility tested in ViX 5.4.000.004, which predates
the ConfigListScreen changes.