### PR TITLE
Cater for TimerEntryBase usage in TimerEntry refactoring.

### DIFF
--- a/vps/src_py/Vps_setup.py
+++ b/vps/src_py/Vps_setup.py
@@ -9,7 +9,7 @@ from Components.ActionMap import ActionMap
 from Components.Sources.StaticText import StaticText
 from Components.config import config, getConfigListEntry
 
-VERSION = "1.31"
+VERSION = "1.32"
 
 class VPS_Setup(Screen, ConfigListScreen):
 


### PR DESCRIPTION
Also includes a comment (but not code) change on the new_TimerEntry_createSetup() call.

This is the dev version, as this has a few relative imports (from .Vps_check...)

The "from __future__ import absolute_import" isn't needed as these relative imports work anyway (and they may as well go into the master version).