### PR TITLE
[EPGRefresh] Extensions menu fix

### DIFF
--- a/epgrefresh/src/EPGRefresh.py
+++ b/epgrefresh/src/EPGRefresh.py
@@ -355,9 +355,10 @@ class EPGRefresh:
 		self.doStopRunningRefresh = False
 		
 		try:
-			from plugin import AdjustExtensionsmenu, housekeepingExtensionsmenu, extStopDescriptor, extPendingServDescriptor
+			from plugin import AdjustExtensionsmenu, housekeepingExtensionsmenu, extStopDescriptor, extPendingServDescriptor, extRunDescriptor
 			AdjustExtensionsmenu(False, extPendingServDescriptor)
 			AdjustExtensionsmenu(False, extStopDescriptor)
+			AdjustExtensionsmenu(True, extRunDescriptor)
 			housekeepingExtensionsmenu(config.plugins.epgrefresh.show_run_in_extensionsmenu, force=True)
 		except:
 			print("[EPGRefresh] Error while removing 'Stop Running EPG-Refresh' to Extensionmenu:")


### PR DESCRIPTION
Make 'Run EPG-Refresh now' return to the extensions (blue button) menu when EPGRefresh finishes running.
Tested on OpenViX 5.4.009.006.