### PR TITLE
[AutoTimer] Output space-separated tags correctly (#418)

### DIFF
--- a/autotimer/src/AutoTimerConfiguration.py
+++ b/autotimer/src/AutoTimerConfiguration.py
@@ -671,6 +671,8 @@ def buildConfig(defaultTimer, timers, webif = False):
 	# Tags
 	if webif and defaultTimer.tags:
 		extend(('  <e2tags>', stringToXML(' '.join(defaultTimer.tags)), '</e2tags>\n'))
+		for tag in defaultTimer.tags:
+			extend(('  <e2tag>', stringToXML(tag), '</e2tag>\n'))
 	else:
 		for tag in defaultTimer.tags:
 			extend(('  <tag>', stringToXML(tag), '</tag>\n'))


### PR DESCRIPTION
Output space-separated tags correctly (#418)

This change outputs autotimer tags individually instead of providing a space-separated list which splits space-separated tags incorrectly.
`<e2tags>` is kept so as not to break existing consumers.