### PR TITLE
Output space-separated tags correctly

### DIFF
--- a/vixautotimer/src/AutoTimerConfiguration.py
+++ b/vixautotimer/src/AutoTimerConfiguration.py
@@ -660,6 +660,8 @@ def buildConfig(defaultTimer, timers, webif = False):
 	# Tags
 	if webif and defaultTimer.tags:
 		extend(('  <e2tags>', stringToXML(' '.join(defaultTimer.tags)), '</e2tags>\n'))
+		for tag in defaultTimer.tags:
+			extend(('  <e2tag>', stringToXML(tag), '</e2tag>\n'))
 	else:
 		for tag in defaultTimer.tags:
 			extend(('  <tag>', stringToXML(tag), '</tag>\n'))


### PR DESCRIPTION
Output space-separated tags correctly

This change outputs autotimer tags individually instead of providing a space-separated list which splits space-separated tags incorrectly.
is kept so as not to break existing consumers.