### PR TITLE
Restore test/simulate ALL

### DIFF
--- a/autotimer/src/AutoTimerResource.py
+++ b/autotimer/src/AutoTimerResource.py
@@ -104,10 +104,9 @@ class AutoTimerTestResource(AutoTimerBaseResource):
 		id = get("id")
 		if id:
 			id = int(id[0])
+			autotimer.parseEPG(simulateOnly=True, uniqueId=id, callback=self.parsecallback)
 		else:
-			return self.returnResult(req, False, _("missing parameter \"id\""))
-
-		autotimer.parseEPG(simulateOnly=True, uniqueId=id, callback=self.parsecallback)
+			autotimer.parseEPG(simulateOnly=True, callback=self.parsecallback)
 		return server.NOT_DONE_YET
 
 	def renderBackground(self, req, timers, skipped):


### PR DESCRIPTION
This change re-enables returning ALL matching AutoTimers when no `id` is passed