### PR TITLE
Update NetworkBrowser.py

### DIFF
--- a/networkbrowserpli/src/NetworkBrowser.py
+++ b/networkbrowserpli/src/NetworkBrowser.py
@@ -21,7 +21,7 @@ from os import path as os_path, stat, mkdir, remove
 from time import time
 from stat import ST_MTIME
 
-import netscan
+from . import netscan
 from .MountManager import AutoMountManager
 from .AutoMount import iAutoMount
 from .MountEdit import AutoMountEdit


### PR DESCRIPTION
Fix "No module named netscan" 
as mentioned [here](https://www.gigablue-support.org/gigablueforum/forum/index.php?thread/14954-nach-update-auf-image-vom-18-9-fehlermeldung/#post129491)