### PR TITLE
[SimpleRSS] Correction of RSSPoller.py

### DIFF
--- a/simplerss/src/RSSPoller.py
+++ b/simplerss/src/RSSPoller.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import print_function
 from __future__ import absolute_import
 
@@ -9,13 +8,15 @@ from Components.config import config
 from enigma import eTimer
 
 from Tools.Notifications import AddPopup
+from Tools.BoundFunction import boundFunction
 from Screens.MessageBox import MessageBox
 
 from .RSSFeed import BaseFeed, UniversalFeed
 
-from twisted.web.client import getPage
+from twisted.web.client import Agent, readBody
+from twisted.internet import reactor
 from xml.etree.cElementTree import fromstring as cElementTree_fromstring
-from six import ensure_binary
+from six import ensure_str, ensure_binary
 
 from .GoogleReader import GoogleReader
 
@@ -115,7 +116,7 @@ class RSSPoller:
 		# Assume its just a temporary failure and jump over to next feed
 		self.next_feed()
 
-	def _gotPage(self, data, id=None, callback=False, errorback=None):
+	def _gotPage(self, id=None, callback=False, errorback=None, data=None):
 		# workaround: exceptions in gotPage-callback were ignored
 		try:
 			self.gotPage(data, id)
@@ -144,6 +145,7 @@ class RSSPoller:
 			self.next_feed()
 
 	def gotPage(self, data, id=None):
+		data = ensure_str(data)
 		feed = cElementTree_fromstring(data)
 
 		# For Single-Polling
@@ -164,7 +166,15 @@ class RSSPoller:
 		self.next_feed()
 
 	def singlePoll(self, id, callback=False, errorback=None):
-		getPage(ensure_binary(self.feeds[id].uri)).addCallback(self.gotPage, id, callback, errorback).addErrback(errorback)
+		agent = Agent(reactor)
+		d = agent.request(b'GET', ensure_binary(self.feeds[id].uri))
+		d.addCallback(boundFunction(self._gotPage2, id, callback, errorback))
+		d.addErrback(errorback)
+
+	def _gotPage2(self, id=None, callback=False, errorback=None, response=None):
+		d = readBody(response)
+		d.addCallback(boundFunction(self._gotPage, id, callback, errorback))
+		return d
 
 	def poll(self):
 		# Reloading, reschedule
@@ -248,11 +258,19 @@ class RSSPoller:
 			feed = self.feeds[self.current_feed]
 
 			if feed.autoupdate:
-				getPage(ensure_binary(feed.uri)).addCallback(self.gotPage).addErrback(self.error)
+				agent = Agent(reactor)
+				d = agent.request(b'GET', ensure_binary(feed.uri))
+				d.addCallback(self._gotPage3)
+				d.addErrback(self.error)
 			# Go to next feed
 			else:
 				print("[SimpleRSS] passing feed")
 				self.next_feed()
+
+	def _gotPage3(self, response=None):
+		d = readBody(response)
+		d.addCallback(boundFunction(self._gotPage, None, False, None))
+		return d
 
 	def next_feed(self):
 		self.current_feed += 1


### PR DESCRIPTION
Resetting the libraries used:
'**twisted.web.client import getPage**' flies out again
'**from twisted.web.client import Agent, readBody & from twisted.internet import reactor**' comes back in