### PR TITLE
Update plugin.py

### DIFF
--- a/remotetimer/src/plugin.py
+++ b/remotetimer/src/plugin.py
@@ -65,7 +65,7 @@ def getPage(url, callback, errback):
 		if PY3:
 			base64string = base64string.encode('utf-8')
 		base64string = b64encode(base64string)
-		authheader = {"Authorization": "Basic %s" % base64string}
+		authheader = {b"Authorization": b"Basic %s" % base64string}
 		print("[remotetimer] Headers=%s" % (authheader))
 		try:
 			r = get(url, headers=authheader)


### PR DESCRIPTION
Update for getting HTTP access to remoteTimer when Authenticate for HTTP in OpenWebIf is enabled.  

See: https://www.opena.tv/plugins/58663-partnerbox-opena-tv-7-0-und-6-4-a-23.html#post538969