### PR TITLE
Support openatv margins

### DIFF
--- a/autotimer/src/AutoTimer.py
+++ b/autotimer/src/AutoTimer.py
@@ -72,7 +72,7 @@ def timeSimilarityPercent(rtimer, evtBegin, evtEnd, timer=None):
 		# remove E2 offset
 		rtimerBegin = rtimer.begin + config.recording.margin_before.value * 60
 		rtimerEnd = rtimer.end - config.recording.margin_after.value * 60
-	#print("trimer [",rtimerBegin,",",rtimerEnd,"] (",rtimerEnd-rtimerBegin," s) after removing offsets")
+	#print("rtimer [",rtimerBegin,",",rtimerEnd,"] (",rtimerEnd-rtimerBegin," s) after removing offsets")
 	if (rtimerBegin <= evtBegin) and (evtEnd <= rtimerEnd):
 		commonTime = evtEnd - evtBegin
 	elif (evtBegin <= rtimerBegin) and (rtimerEnd <= evtEnd):
@@ -570,6 +570,7 @@ class AutoTimer:
 			# Overwrite endtime if requested
 			if timer.justplay and not timer.setEndtime:
 				end = begin
+				offsetEnd = 0
 
 			# Eventually change service to alternative
 			if timer.overrideAlternatives:
@@ -695,6 +696,7 @@ class AutoTimer:
 
 			newEntry.dirname = timer.destination
 			newEntry.justplay = timer.justplay
+			newEntry.hasEndTime = timer.setEndtime
 			newEntry.vpsplugin_enabled = timer.vps_enabled
 			newEntry.vpsplugin_overwrite = timer.vps_overwrite
 

--- a/autotimer/src/AutoTimerEditor.py
+++ b/autotimer/src/AutoTimerEditor.py
@@ -917,7 +917,7 @@ class AutoTimerEditor(Screen, ConfigListScreen, AutoTimerEditorBase):
 
 		# Offset
 		if self.offset.value:
-			if not self.setEndtime.value:
+			if self.justplay.value == "zap" and not self.setEndtime.value:
 				self.offsetend.value = 0
 			self.timer.offset = (self.offsetbegin.value * 60, self.offsetend.value * 60)
 		else:
@@ -1049,7 +1049,7 @@ class AutoTimerEditorSilent(AutoTimerEditor):
 
 		# Offset
 		if self.offset.value:
-			if not self.setEndtime.value:
+			if self.justplay.value == "zap" and not self.setEndtime.value:
 				self.offsetend.value = 0
 			self.timer.offset = (self.offsetbegin.value * 60, self.offsetend.value * 60)
 		else:


### PR DESCRIPTION
- Fix typo
- Support openatv margins(margin_before, zap_margin_before, margin_after, zap_margin_after) as default on editor fix(https://github.com/oe-alliance/enigma2-plugins/issues/625)
- Support openatv zap_has_endtime