### PR TITLE
[EPG Search] Jump to search result nearest current time

### DIFF
--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -33,7 +33,7 @@ from Components.Sources.StaticText import StaticText
 
 from Tools.BoundFunction import boundFunction
 
-from time import localtime, strftime
+from time import localtime, strftime, time
 from operator import itemgetter
 from collections import defaultdict
 

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -677,6 +677,19 @@ class EPGSearch(EPGSelection):
 		l.instance.setSelectionEnable(True)
 		l.list = ret
 		l.l.setList(ret)
+		# jump to entry nearest current time, copied from 
+		# https://github.com/openatv/enigma2/blob/628e1a712c59fca16793b225b393a59417072ba6/lib/python/Components/EpgList.py#L1460
+		t = time()
+		epg_time = t - config.epg.histminutes.value * 60
+		if t != epg_time:
+			idx = 0
+			for x in l.list:
+				idx += 1
+				if t < x[2] + x[3]:
+					break
+			l.instance.moveSelectionTo(idx - 1)
+		else:
+			l.instance.moveSelectionTo(1)
 		l.recalcEntrySize()
 
 	def _filteredSearchByName(self, args, maxRet, search_type, searchString, search_case, searchFilter):

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -677,10 +677,14 @@ class EPGSearch(EPGSelection):
 		l.instance.setSelectionEnable(True)
 		l.list = ret
 		l.l.setList(ret)
-		# jump to entry nearest current time, copied from 
+
+		# jump to entry neearest current time, copied from 
 		# https://github.com/openatv/enigma2/blob/628e1a712c59fca16793b225b393a59417072ba6/lib/python/Components/EpgList.py#L1460
 		t = time()
-		epg_time = t - config.epg.histminutes.value * 60
+		histminutes = 0
+		if hasattr(config.epg, "histminutes"):
+			histminutes = config.epg.histminutes.value * 60
+		epg_time = t - histminutes
 		if t != epg_time:
 			idx = 0
 			for x in l.list:
@@ -690,6 +694,7 @@ class EPGSearch(EPGSelection):
 			l.instance.moveSelectionTo(idx - 1)
 		else:
 			l.instance.moveSelectionTo(1)
+
 		l.recalcEntrySize()
 
 	def _filteredSearchByName(self, args, maxRet, search_type, searchString, search_case, searchFilter):

--- a/epgsearch/src/EPGSearch.py
+++ b/epgsearch/src/EPGSearch.py
@@ -681,10 +681,10 @@ class EPGSearch(EPGSelection):
 		# jump to entry neearest current time, copied from 
 		# https://github.com/openatv/enigma2/blob/628e1a712c59fca16793b225b393a59417072ba6/lib/python/Components/EpgList.py#L1460
 		t = time()
-		histminutes = 0
+		histhours = 0
 		if hasattr(config.epg, "histminutes"):
-			histminutes = config.epg.histminutes.value * 60
-		epg_time = t - histminutes
+			histhours = config.epg.histminutes.value * 60
+		epg_time = t - histhours
 		if t != epg_time:
 			idx = 0
 			for x in l.list:


### PR DESCRIPTION
This change places the cursor on the search result entry closest to the current time.

This change does not cause past events to be faded out as happens in Single-channel EPG.

![epgsearch-cursor-20231129172439](https://github.com/oe-alliance/enigma2-plugins/assets/9741693/82e63db4-92d1-44ce-8e71-9b7ff8d9ab5e)
